### PR TITLE
fix(): Fixing cluster labels

### DIFF
--- a/internal/hub/manager/manager.go
+++ b/internal/hub/manager/manager.go
@@ -86,7 +86,7 @@ func Start(meshClient client.Client, ctx context.Context) {
 		ControllerManagedBy(mgr).
 		For(&spokev1alpha1.WorkerSliceConfig{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return object.GetLabels()["spoke-cluster"] == ClusterName
+			return object.GetLabels()["worker-cluster"] == ClusterName
 		})).
 		Complete(sliceReconciler)
 	if err != nil {
@@ -106,7 +106,7 @@ func Start(meshClient client.Client, ctx context.Context) {
 		ControllerManagedBy(mgr).
 		For(&spokev1alpha1.WorkerSliceGateway{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return object.GetLabels()["spoke-cluster"] == ClusterName
+			return object.GetLabels()["worker-cluster"] == ClusterName
 		})).
 		Complete(sliceGwReconciler)
 	if err != nil {
@@ -124,7 +124,7 @@ func Start(meshClient client.Client, ctx context.Context) {
 		ControllerManagedBy(mgr).
 		For(&spokev1alpha1.WorkerServiceImport{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return object.GetLabels()["spoke-cluster"] == ClusterName
+			return object.GetLabels()["worker-cluster"] == ClusterName
 		})).
 		Complete(serviceImportReconciler)
 	if err != nil {

--- a/tests/hub/hub_suite_test.go
+++ b/tests/hub/hub_suite_test.go
@@ -135,7 +135,7 @@ var _ = BeforeSuite(func() {
 		ControllerManagedBy(k8sManager).
 		For(&spokev1alpha1.WorkerSliceConfig{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return object.GetLabels()["spoke-cluster"] == CLUSTER_NAME
+			return object.GetLabels()["worker-cluster"] == CLUSTER_NAME
 		})).
 		Complete(sr)
 	Expect(err).ToNot(HaveOccurred())
@@ -144,7 +144,7 @@ var _ = BeforeSuite(func() {
 		ControllerManagedBy(k8sManager).
 		For(&spokev1alpha1.WorkerSliceGateway{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
-			return object.GetLabels()["spoke-cluster"] == CLUSTER_NAME
+			return object.GetLabels()["worker-cluster"] == CLUSTER_NAME
 		})).
 		Complete(sgwr)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Hub SliceController", func() {
 					Name:      "test-slice-1",
 					Namespace: PROJECT_NS,
 					Labels: map[string]string{
-						"spoke-cluster": CLUSTER_NAME,
+						"worker-cluster": CLUSTER_NAME,
 					},
 				},
 				Spec: spokev1alpha1.WorkerSliceConfigSpec{
@@ -126,7 +126,7 @@ var _ = Describe("Hub SliceController", func() {
 					Name:      "test-slice-2",
 					Namespace: PROJECT_NS,
 					Labels: map[string]string{
-						"spoke-cluster": CLUSTER_NAME,
+						"worker-cluster": CLUSTER_NAME,
 					},
 				},
 				Spec: spokev1alpha1.WorkerSliceConfigSpec{
@@ -175,7 +175,7 @@ var _ = Describe("Hub SliceController", func() {
 					Name:      "test-slice-3",
 					Namespace: PROJECT_NS,
 					Labels: map[string]string{
-						"spoke-cluster": CLUSTER_NAME,
+						"worker-cluster": CLUSTER_NAME,
 					},
 				},
 				Spec: spokev1alpha1.WorkerSliceConfigSpec{

--- a/tests/hub/slicegw_controller_test.go
+++ b/tests/hub/slicegw_controller_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Hub SlicegwController", func() {
 					Name:      "test-slice",
 					Namespace: PROJECT_NS,
 					Labels: map[string]string{
-						"spoke-cluster": CLUSTER_NAME,
+						"worker-cluster": CLUSTER_NAME,
 					},
 				},
 				Spec: spokev1alpha1.WorkerSliceConfigSpec{
@@ -62,7 +62,7 @@ var _ = Describe("Hub SlicegwController", func() {
 					Name:      "test-slicegateway",
 					Namespace: PROJECT_NS,
 					Labels: map[string]string{
-						"spoke-cluster": CLUSTER_NAME,
+						"worker-cluster": CLUSTER_NAME,
 					},
 				},
 				Spec: spokev1alpha1.WorkerSliceGatewaySpec{


### PR DESCRIPTION
cluster label used was spoke-cluster, updated it to worker-cluster. 

Without this, reconciliation was not getting scheduled on worker clusters

Signed-off-by: gourishkb <104021126+gourishkb@users.noreply.github.com>