### PR TITLE
update values.yaml to use non raw.github link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ kind load docker-image <my-custom-image>:<unique-tag> --name <cluster-name>
 ### Deploying in a cluster
 
 Create chart values file `yourvaluesfile.yaml`.
-Refer to [values.yaml](https://github.com/kubeslice/charts/blob/master/kubeslice-worker/values.yaml) on how to adjust this and update the operator image the local image.
+Refer to [values.yaml](https://github.com/kubeslice/charts/blob/master/kubeslice-worker/values.yaml) to create `yourvaluesfiel.yaml` and update the operator image subsection to use the local image.
 
 From the sample , 
 


### PR DESCRIPTION
Earlier link was a raw.github.com link, since the content changed the raw.github link was broken. 

Making the link point to github repo instead so that the link is updated each time the charts repo is updated