### PR TITLE
replaced mesh-dns with kubesice-dns and passed the sidecare emulator …

### DIFF
--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -56,7 +56,7 @@ var _ = Describe("SliceController", func() {
 
 			svc = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mesh-dns",
+					Name:      "kubeslice-dns",
 					Namespace: "kubeslice-system",
 				},
 				Spec: corev1.ServiceSpec{
@@ -86,7 +86,7 @@ var _ = Describe("SliceController", func() {
 			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, svc)).Should(Succeed())
 
-			svcKey := types.NamespacedName{Name: "mesh-dns", Namespace: "kubeslice-system"}
+			svcKey := types.NamespacedName{Name: "kubeslice-dns", Namespace: "kubeslice-system"}
 			createdSvc := &corev1.Service{}
 
 			// Wait until service is created properly
@@ -149,7 +149,7 @@ var _ = Describe("SliceController", func() {
 
 			svc = &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mesh-dns",
+					Name:      "kubeslice-dns",
 					Namespace: "kubeslice-system",
 				},
 				Spec: corev1.ServiceSpec{
@@ -213,7 +213,7 @@ var _ = Describe("SliceController", func() {
 			Expect(k8sClient.Create(ctx, svcexport)).Should(Succeed())
 
 			createdSvc := &corev1.Service{}
-			svcKey := types.NamespacedName{Name: "mesh-dns", Namespace: "kubeslice-system"}
+			svcKey := types.NamespacedName{Name: "kubeslice-dns", Namespace: "kubeslice-system"}
 
 			// Wait until service is created properly
 			Eventually(func() bool {

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -121,6 +121,15 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	workerClientSidecarGwEmulator, err = workergw.NewClientEmulator()
+	Expect(err).ToNot(HaveOccurred())
+
+	workerClientRouterEmulator, err = workerrouter.NewClientEmulator()
+	Expect(err).ToNot(HaveOccurred())
+
+	workerClientNetopEmulator, err = workernetop.NewClientEmulator()
+	Expect(err).ToNot(HaveOccurred())
+
 	err = (&slice.SliceReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),
@@ -128,7 +137,9 @@ var _ = BeforeSuite(func() {
 		EventRecorder: &events.EventRecorder{
 			Recorder: &record.FakeRecorder{},
 		},
-		HubClient: hubClientEmulator,
+		HubClient:          hubClientEmulator,
+		WorkerRouterClient: workerClientRouterEmulator,
+		WorkerNetOpClient:  workerClientNetopEmulator,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -144,15 +155,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	testSvcExEventRecorder := events.NewEventRecorder(k8sManager.GetEventRecorderFor("test-SvcEx-controller"))
-
-	workerClientSidecarGwEmulator, err = workergw.NewClientEmulator()
-	Expect(err).ToNot(HaveOccurred())
-
-	workerClientRouterEmulator, err = workerrouter.NewClientEmulator()
-	Expect(err).ToNot(HaveOccurred())
-
-	workerClientNetopEmulator, err = workernetop.NewClientEmulator()
-	Expect(err).ToNot(HaveOccurred())
 
 	err = (&slicegateway.SliceGwReconciler{
 		Client: k8sManager.GetClient(),


### PR DESCRIPTION
…while intializing slice reconciler

Signed-off-by: kon3m <aakash.dokka@aveshasystems.com>