### PR TITLE
Handle nsm IP address change of slice gw and app pods

### DIFF
--- a/controllers/serviceexport/reconciler.go
+++ b/controllers/serviceexport/reconciler.go
@@ -174,10 +174,13 @@ func (r Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 	}
 
 	res, err, requeue := r.ReconcileAppPod(ctx, serviceexport)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	if requeue {
 		log.Info("app pods reconciled")
 		debugLog.Info("requeuing after app pod reconcile", "res", res, "er", err)
-		return res, err
+		return res, nil
 	}
 
 	if serviceexport.Status.LastSync == 0 {

--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -265,7 +265,7 @@ func (r *SliceReconciler) unbindAppNamespace(ctx context.Context, slice *kubesli
 	namespace := &corev1.Namespace{}
 	err := r.Get(ctx, types.NamespacedName{Name: appNs}, namespace)
 	//namespace might be deleted by user/admin
-	if errors.IsNotFound(err){
+	if errors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {

--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -302,21 +302,35 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
+func getPodType(labels map[string]string) string {
+	podType, found := labels["avesha.io/pod-type"]
+	if found {
+		return podType
+	}
+
+	nsmLabel, found := labels["app"]
+	if found {
+		if nsmLabel == "nsmgr-daemonset" || nsmLabel == "nsm-kernel-plane" {
+			return "nsm"
+		}
+	}
+
+	return ""
+}
+
 func (r *SliceGwReconciler) findSliceGwObjectsToReconcile(pod client.Object) []reconcile.Request {
 	podLabels := pod.GetLabels()
 	if podLabels == nil {
 		return []reconcile.Request{}
 	}
 
-	podType, found := podLabels["avesha.io/pod-type"]
-	if !found {
-		return []reconcile.Request{}
-	}
+	podType := getPodType(podLabels)
 
 	sliceGwList := &kubeslicev1beta1.SliceGatewayList{}
 	var err error
 
-	if podType == "router" {
+	switch podType {
+	case "router":
 		sliceName, found := podLabels["avesha.io/slice"]
 		if !found {
 			return []reconcile.Request{}
@@ -326,12 +340,17 @@ func (r *SliceGwReconciler) findSliceGwObjectsToReconcile(pod client.Object) []r
 		if err != nil {
 			return []reconcile.Request{}
 		}
-	} else if podType == "netop" {
+	case "netop":
 		sliceGwList, err = r.findObjectsForNetopUpdate()
 		if err != nil {
 			return []reconcile.Request{}
 		}
-	} else {
+	case "nsm":
+		sliceGwList, err = r.findObjectsForNsmUpdate()
+		if err != nil {
+			return []reconcile.Request{}
+		}
+	default:
 		return []reconcile.Request{}
 	}
 
@@ -361,7 +380,7 @@ func (r *SliceGwReconciler) findObjectsForSliceRouterUpdate(sliceName string) (*
 	return sliceGwList, nil
 }
 
-func (r *SliceGwReconciler) findObjectsForNetopUpdate() (*kubeslicev1beta1.SliceGatewayList, error) {
+func (r *SliceGwReconciler) findAllSliceGwObjects() (*kubeslicev1beta1.SliceGatewayList, error) {
 	sliceGwList := &kubeslicev1beta1.SliceGatewayList{}
 	listOpts := []client.ListOption{
 		client.InNamespace(controllers.ControlPlaneNamespace),
@@ -372,6 +391,14 @@ func (r *SliceGwReconciler) findObjectsForNetopUpdate() (*kubeslicev1beta1.Slice
 	}
 
 	return sliceGwList, nil
+}
+
+func (r *SliceGwReconciler) findObjectsForNetopUpdate() (*kubeslicev1beta1.SliceGatewayList, error) {
+	return r.findAllSliceGwObjects()
+}
+
+func (r *SliceGwReconciler) findObjectsForNsmUpdate() (*kubeslicev1beta1.SliceGatewayList, error) {
+	return r.findAllSliceGwObjects()
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -394,6 +421,22 @@ func (r *SliceGwReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	labelSelector.MatchLabels = map[string]string{"app": "nsmgr-daemonset"}
+	nsmgrPredicate, err := predicate.LabelSelectorPredicate(labelSelector)
+	if err != nil {
+		return err
+	}
+
+	labelSelector.MatchLabels = map[string]string{"app": "nsm-kernel-plane"}
+	nsmfwdPredicate, err := predicate.LabelSelectorPredicate(labelSelector)
+	if err != nil {
+		return err
+	}
+
+	sliceGwUpdPredicate := predicate.Or(
+		slicerouterPredicate, netopPredicate, nsmgrPredicate, nsmfwdPredicate,
+	)
+
 	// The mapping function for the slice router pod update should only invoke the reconciler
 	// of the slice gateway objects that belong to the same slice as the restarted slice router.
 	// The netop pods are slice agnostic. Hence, all slice gateway objects belonging to every slice
@@ -405,11 +448,7 @@ func (r *SliceGwReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Watches(&source.Kind{Type: &corev1.Pod{}},
 			handler.EnqueueRequestsFromMapFunc(r.findSliceGwObjectsToReconcile),
-			builder.WithPredicates(slicerouterPredicate),
-		).
-		Watches(&source.Kind{Type: &corev1.Pod{}},
-			handler.EnqueueRequestsFromMapFunc(r.findSliceGwObjectsToReconcile),
-			builder.WithPredicates(netopPredicate),
+			builder.WithPredicates(sliceGwUpdPredicate),
 		).
 		Complete(r)
 }

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -146,7 +146,6 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	
 	err = (&serviceexport.Reconciler{
 		Client:    k8sManager.GetClient(),
 		Scheme:    k8sManager.GetScheme(),


### PR DESCRIPTION
Handled the case of nsm IP address change of slice gw due to nsm control
plane or data plane pods restarting.

For Istio, handled the case of nsm IP address change of an app pod that is
exporting a service. Updated the corresponding Istio ServiceEntry
object.