### PR TITLE
Feature enhance netpol

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -27,6 +27,8 @@ import (
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -36,7 +38,13 @@ import (
 )
 
 var (
-	log logr.Logger = logger.NewLogger()
+	log                        logr.Logger = logger.NewLogger()
+	allowedNamespacesByDefault             = []string{"kubeslice-system", "kube-system", "istio-system"}
+)
+
+const (
+	ApplicationNamespaceSelectorLabelKey = "kubeslice.io/slice"
+	AllowedNamespaceSelectorLabelKey     = "kubeslice.io/namespace"
 )
 
 // GetSlice returns slice object by slice name
@@ -130,4 +138,76 @@ func SliceAppNamespaceConfigured(ctx context.Context, slice string, namespace st
 		}
 	}
 	return false, nil
+}
+
+func ContructNetworkPolicyObject(ctx context.Context, slice *kubeslicev1beta1.Slice, appNs string) *networkingv1.NetworkPolicy {
+	netPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      slice.Name + "-" + appNs,
+			Namespace: appNs,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				networkingv1.NetworkPolicyIngressRule{
+					From: []networkingv1.NetworkPolicyPeer{
+						networkingv1.NetworkPolicyPeer{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{ApplicationNamespaceSelectorLabelKey: slice.Name},
+							},
+						},
+					},
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				networkingv1.NetworkPolicyEgressRule{
+					To: []networkingv1.NetworkPolicyPeer{
+						networkingv1.NetworkPolicyPeer{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{ApplicationNamespaceSelectorLabelKey: slice.Name},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var cfgAllowedNsList []string
+	cfgAllowedNsList = slice.Status.SliceConfig.NamespaceIsolationProfile.AllowedNamespaces
+	// traffic from "kubeslice-system","istio-system","kube-system" namespaces is allowed by default
+	for _, v := range allowedNamespacesByDefault {
+		if !exists(cfgAllowedNsList, v) {
+			cfgAllowedNsList = append(cfgAllowedNsList, v)
+		}
+	}
+	for _, allowedNs := range cfgAllowedNsList {
+		ingressRule := networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{AllowedNamespaceSelectorLabelKey: allowedNs},
+			},
+		}
+		netPolicy.Spec.Ingress[0].From = append(netPolicy.Spec.Ingress[0].From, ingressRule)
+
+		egressRule := networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{AllowedNamespaceSelectorLabelKey: allowedNs},
+			},
+		}
+		netPolicy.Spec.Egress[0].To = append(netPolicy.Spec.Egress[0].To, egressRule)
+	}
+	return netPolicy
+}
+
+func exists(i []string, o string) bool {
+	for _, v := range i {
+		if v == o {
+			return true
+		}
+	}
+	return false
 }

--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -48,7 +48,7 @@ func (r *SliceReconciler) ReconcileSliceNamespaces(ctx context.Context, slice *k
 	if err != nil {
 		return ctrl.Result{}, err, true
 	}
-	if !slice.Status.SliceConfig.NamespaceIsolationProfile.IsolationEnabled {
+	if slice.Status.SliceConfig.NamespaceIsolationProfile != nil && !slice.Status.SliceConfig.NamespaceIsolationProfile.IsolationEnabled {
 		// IsolationEnabled is either turned off or toggled off
 		// if NetworkPoliciesInstalled is enabled, this means there are netpol installed in appnamespaces we need to remove
 		if slice.Status.NetworkPoliciesInstalled {

--- a/pkg/networkpolicy/reconciler.go
+++ b/pkg/networkpolicy/reconciler.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/go-logr/logr"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
+	"github.com/kubeslice/worker-operator/controllers"
 	slicepkg "github.com/kubeslice/worker-operator/controllers/slice"
 	"github.com/kubeslice/worker-operator/pkg/events"
 	corev1 "k8s.io/api/core/v1"
@@ -107,18 +109,30 @@ func (r *NetpolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 
-	//if this network policy is the one installed by slice reconciler, we ignore it
-	if strings.EqualFold(sliceName+"-"+netpol.Namespace, netpol.Name) {
-		//early exit
-		log.Info("added/modified network policy,ignoring since it is reconciled by slice reconciler")
-		return ctrl.Result{}, nil
-	}
 	//get slice
 	slice := &kubeslicev1beta1.Slice{}
 	err = r.Get(context.Background(), types.NamespacedName{Name: sliceName, Namespace: "kubeslice-system"}, slice)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("error while retrieving slice(%s/%s)", "kubeslice-system", sliceName))
 		return ctrl.Result{}, err
+	}
+
+	//if this network policy is the one installed by slice reconciler, compare it with slice netpol
+	//contructed from slice object
+	if strings.EqualFold(sliceName+"-"+netpol.Namespace, netpol.Name) {
+		log.Info("added/modified network policy installed by slice recocniler,reconciling")
+
+		sliceNetpol := controllers.ContructNetworkPolicyObject(ctx, slice, netpol.Namespace)
+		if !reflect.DeepEqual(sliceNetpol.Spec, netpol.Spec) {
+			// netpol changed
+			log.Info("network policy installed by slice recocniler is modified,reconciling")
+			netpol.Spec = sliceNetpol.Spec
+			err := r.Update(ctx, &netpol)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
 	}
 
 	//extra network policy being added , compare and raise an event

--- a/tests/spoke/slice_netpol_test.go
+++ b/tests/spoke/slice_netpol_test.go
@@ -25,7 +25,7 @@ const (
 	interval = time.Millisecond * 250
 )
 
-var _ = Describe("SliceNetpol", func() {
+var _ = FDescribe("SliceNetpol", func() {
 	var slice *kubeslicev1beta1.Slice
 	var svc *corev1.Service
 	var createdSlice *kubeslicev1beta1.Slice

--- a/tests/spoke/slice_netpol_test.go
+++ b/tests/spoke/slice_netpol_test.go
@@ -25,7 +25,7 @@ const (
 	interval = time.Millisecond * 250
 )
 
-var _ = FDescribe("SliceNetpol", func() {
+var _ = Describe("SliceNetpol", func() {
 	var slice *kubeslicev1beta1.Slice
 	var svc *corev1.Service
 	var createdSlice *kubeslicev1beta1.Slice


### PR DESCRIPTION
Fixes #37 
Problem: Since slice reconciler reconciles every 10 secs, the reconciler would call apiserver to netpol (even though it is not updated) .
Fix: slice reconciler would only install/update netpol when application/allowed namespaces are updated.
User edits to netpol would be handled by networkpolicy reconciler