### PR TITLE
fix(DEVOPS-810): check deploy annotations for nil before accessing them

### DIFF
--- a/pkg/webhook/deploy/webhook.go
+++ b/pkg/webhook/deploy/webhook.go
@@ -85,6 +85,9 @@ func (wh *WebhookServer) InjectDecoder(d *admission.Decoder) error {
 
 func Mutate(deploy *appsv1.Deployment, sliceName string) *appsv1.Deployment {
 	// Add injection status to deployment annotations
+	if deploy.Annotations == nil {
+		deploy.Annotations = map[string]string{}
+	}
 	deploy.Annotations[AdmissionWebhookAnnotationStatusKey] = "injected"
 
 	if deploy.Spec.Template.ObjectMeta.Annotations == nil {


### PR DESCRIPTION
fixes #78 
Mutating webhook injects a key into deploy annotations.
but annotations can be nil
This PR initializes annotations if it is nil