### PR TITLE
fix(AM-4841): fix for geolocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/kubeslice/apis v0.0.0-20220720101728-b77f56377257
+	github.com/kubeslice/apis v0.0.0-20220805102951-cb062949a0b0
 	github.com/kubeslice/gateway-sidecar v0.1.1
 	github.com/kubeslice/netops v0.0.0-20220506082959-81fef290c265
 	github.com/kubeslice/router-sidecar v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -453,6 +453,8 @@ github.com/kubeslice/apis v0.0.0-20220518055057-d36bcfb73b97 h1:dyyVck2Ka3I/jehD
 github.com/kubeslice/apis v0.0.0-20220518055057-d36bcfb73b97/go.mod h1:YDSfpIsQM+FtQPaZVGNCTZnlp3viWuQhkjJjIHQdaYs=
 github.com/kubeslice/apis v0.0.0-20220720101728-b77f56377257 h1:mTqmYuVGX93WcoJvESPnH1jSpixY0Zks3xj1hNI6YII=
 github.com/kubeslice/apis v0.0.0-20220720101728-b77f56377257/go.mod h1:YDSfpIsQM+FtQPaZVGNCTZnlp3viWuQhkjJjIHQdaYs=
+github.com/kubeslice/apis v0.0.0-20220805102951-cb062949a0b0 h1:afUy/YCVwiDC3rMowAUJq5q1wmazwHSti0INgIGYpOc=
+github.com/kubeslice/apis v0.0.0-20220805102951-cb062949a0b0/go.mod h1:YDSfpIsQM+FtQPaZVGNCTZnlp3viWuQhkjJjIHQdaYs=
 github.com/kubeslice/gateway-sidecar v0.1.1 h1:FjOaGfWSOpEbQlNtID39tQFES6e4Jisj7LPy6BYr1C4=
 github.com/kubeslice/gateway-sidecar v0.1.1/go.mod h1:grTac1B4A6CsMkpjGp493CwDQhD3oExHwYFLKeE3how=
 github.com/kubeslice/netops v0.0.0-20220506082959-81fef290c265 h1:2NWAlXUz3z7bNk9JW8w0EGlB6iJqV2q77v74etzf60I=

--- a/pkg/hub/hubclient/hubclient.go
+++ b/pkg/hub/hubclient/hubclient.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	GCP string = "gcp"
-	AWS string = "aws"
+	GCP   string = "gcp"
+	AWS   string = "aws"
 	AZURE string = "azure"
 )
 

--- a/pkg/hub/hubclient/hubclient.go
+++ b/pkg/hub/hubclient/hubclient.go
@@ -43,6 +43,12 @@ import (
 	"github.com/kubeslice/worker-operator/pkg/logger"
 )
 
+const (
+	GCP string = "gcp"
+	AWS string = "aws"
+	AZURE string = "azure"
+)
+
 var scheme = runtime.NewScheme()
 var log = logger.NewLogger().WithValues("type", "hub")
 
@@ -249,8 +255,12 @@ func updateClusterInfoToHub(ctx context.Context, spokeclient client.Client, hubC
 			return err
 		}
 		log.Info("cniSubnet", "cniSubnet", cniSubnet)
-		hubCluster.Spec.ClusterProperty.GeoLocation.CloudRegion = clusterInfo.ClusterProperty.GeoLocation.CloudRegion
-		hubCluster.Spec.ClusterProperty.GeoLocation.CloudProvider = clusterInfo.ClusterProperty.GeoLocation.CloudProvider
+
+		// worker operator to only update Geolocation related values for gcp,aws and azure
+		if clusterInfo.ClusterProperty.GeoLocation.CloudProvider == GCP || clusterInfo.ClusterProperty.GeoLocation.CloudProvider == AWS || clusterInfo.ClusterProperty.GeoLocation.CloudProvider == AZURE {
+			hubCluster.Spec.ClusterProperty.GeoLocation.CloudRegion = clusterInfo.ClusterProperty.GeoLocation.CloudRegion
+			hubCluster.Spec.ClusterProperty.GeoLocation.CloudProvider = clusterInfo.ClusterProperty.GeoLocation.CloudProvider
+		}
 		hubCluster.Spec.NodeIP = nodeIP
 		if err := hubClient.Update(ctx, hubCluster); err != nil {
 			log.Error(err, "Error updating to cluster spec on hub cluster")

--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -285,10 +285,11 @@ var _ = Describe("SliceController", func() {
 
 			status := kubeslicev1beta1.SliceStatus{
 				SliceConfig: &kubeslicev1beta1.SliceConfig{
-					SliceDisplayName: "test-slice",
-					SliceSubnet:      "10.0.0.1/16",
-					SliceID:          "test-slice",
-					SliceType:        "Application",
+					SliceDisplayName:  "test-slice",
+					SliceSubnet:       "10.0.0.1/16",
+					SliceID:           "test-slice",
+					SliceType:         "Application",
+					ClusterSubnetCIDR: "1.1.1.1/16",
 				},
 			}
 
@@ -303,7 +304,8 @@ var _ = Describe("SliceController", func() {
 					return err
 				}
 				createdSlice.Status = status
-				return k8sClient.Status().Update(ctx, createdSlice)
+				err = k8sClient.Status().Update(ctx, createdSlice)
+				return err
 			}, time.Second*20, time.Millisecond*1000).Should(BeNil())
 
 			sliceRouterKey := types.NamespacedName{Name: "vl3-slice-router-test-slice", Namespace: "kubeslice-system"}
@@ -316,7 +318,7 @@ var _ = Describe("SliceController", func() {
 					return false
 				}
 				return createdSliceRouter.Name == "vl3-slice-router-test-slice"
-			}, time.Second*20, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*60, time.Millisecond*250).Should(BeTrue())
 
 			// verify router container images
 			Expect(createdSliceRouter.Spec.Template.Spec.Containers[0].Image).To(Equal("vl3-test"))

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&slice.SliceReconciler{
-		Client: k8sManager.GetClient(),
+		Client: k8sClient,
 		Scheme: k8sManager.GetScheme(),
 		Log:    ctrl.Log.WithName("SliceTest"),
 		EventRecorder: &events.EventRecorder{

--- a/vendor/github.com/kubeslice/apis/pkg/controller/v1alpha1/cluster_types.go
+++ b/vendor/github.com/kubeslice/apis/pkg/controller/v1alpha1/cluster_types.go
@@ -59,6 +59,10 @@ type GeoLocation struct {
 	CloudProvider string `json:"cloudProvider,omitempty"`
 	//CloudRegion is the region of the cloud
 	CloudRegion string `json:"cloudRegion,omitempty"`
+	//Latitude is the latitude of the cluster
+	Latitude string `json:"latitude,omitempty"`
+	//Longitude is the longitude of the cluster
+	Longitude string `json:"longitude,omitempty"`
 }
 
 // Monitoring defines the field of ClusterSpec

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -83,7 +83,7 @@ github.com/googleapis/gnostic/openapiv2
 github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.12
 github.com/json-iterator/go
-# github.com/kubeslice/apis v0.0.0-20220720101728-b77f56377257
+# github.com/kubeslice/apis v0.0.0-20220805102951-cb062949a0b0
 ## explicit
 github.com/kubeslice/apis/pkg/controller/v1alpha1
 github.com/kubeslice/apis/pkg/worker/v1alpha1


### PR DESCRIPTION
This PR fixes the overriding geolocation lat and long data in cluster CR and only sends geolocation data in case in aws,azure and gcp.
also fixes the test cases failing in master