### PR TITLE
fix(AM-4902): fix nodePort value populating as 0

### DIFF
--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -144,7 +144,7 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// true if the gateway is openvpn server
 	// Check if the Gw service already exists, if not create a new one if it is a server
 	if isServer(sliceGw) {
-		reconcile, result, sliceGwNodePort ,err = r.handleSliceGwSvcCreation(ctx, sliceGw)
+		reconcile, result, sliceGwNodePort, err = r.handleSliceGwSvcCreation(ctx, sliceGw)
 		if reconcile {
 			return result, err
 		}
@@ -274,7 +274,7 @@ func isServer(sliceGw *kubeslicev1beta1.SliceGateway) bool {
 func canDeployGw(sliceGw *kubeslicev1beta1.SliceGateway) bool {
 	return sliceGw.Status.Config.SliceGatewayHostType == "Server" || readyToDeployGwClient(sliceGw)
 }
-func (r *SliceGwReconciler) handleSliceGwSvcCreation(ctx context.Context, sliceGw *kubeslicev1beta1.SliceGateway) (bool, reconcile.Result, int32,error) {
+func (r *SliceGwReconciler) handleSliceGwSvcCreation(ctx context.Context, sliceGw *kubeslicev1beta1.SliceGateway) (bool, reconcile.Result, int32, error) {
 	log := logger.FromContext(ctx).WithName("slicegw-create-service")
 	sliceGwName := sliceGw.Name
 
@@ -288,12 +288,12 @@ func (r *SliceGwReconciler) handleSliceGwSvcCreation(ctx context.Context, sliceG
 			err = r.Create(ctx, svc)
 			if err != nil {
 				log.Error(err, "Failed to create new Service", "Namespace", svc.Namespace, "Name", svc.Name)
-				return true, ctrl.Result{},0,err
+				return true, ctrl.Result{}, 0, err
 			}
-			return true, ctrl.Result{Requeue: true}, 0 ,nil
+			return true, ctrl.Result{Requeue: true}, 0, nil
 		}
 		log.Error(err, "Failed to get Service")
-		return true, ctrl.Result{}, 0 ,err
+		return true, ctrl.Result{}, 0, err
 	}
 
 	sliceGwNodePort := foundsvc.Spec.Ports[0].NodePort
@@ -309,13 +309,13 @@ func (r *SliceGwReconciler) handleSliceGwSvcCreation(ctx context.Context, sliceG
 				Message:   "Unable to post NodePort to kubeslice-controller cluster",
 			},
 		)
-		return true, ctrl.Result{},sliceGwNodePort ,err
+		return true, ctrl.Result{}, sliceGwNodePort, err
 	}
 
 	if err := r.reconcileNodes(ctx, sliceGw); err != nil {
-		return true, ctrl.Result{},sliceGwNodePort ,err
+		return true, ctrl.Result{}, sliceGwNodePort, err
 	}
-	return false, reconcile.Result{},sliceGwNodePort ,nil
+	return false, reconcile.Result{}, sliceGwNodePort, nil
 }
 
 func (r *SliceGwReconciler) handleSliceGwDeletion(sliceGw *kubeslicev1beta1.SliceGateway, ctx context.Context) (bool, reconcile.Result, error) {


### PR DESCRIPTION
While refactoring changes for sonarqube warnings , sliceGwNodePort was passed to a different function but its value was never returned back hence the value was being set as 0.
This PR fixes this issue