### PR TITLE
Fix(AM-5066): Sending Slice QoS profile to VPN sidecar

### DIFF
--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -211,7 +211,7 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return res, nil
 	}
 
-	res, err, requeue = r.SendConnectionContextToGwPod(ctx, sliceGw)
+	res, err, requeue = r.SendConnectionContextToGwPodAndQos(ctx, slice, sliceGw)
 	if err != nil {
 		log.Error(err, "Failed to send connection context to gw pod")
 		//post event to slicegw

--- a/controllers/slicegateway/slicegateway.go
+++ b/controllers/slicegateway/slicegateway.go
@@ -623,7 +623,7 @@ func (r *SliceGwReconciler) SendConnectionContextToGwPodAndQos(ctx context.Conte
 
 	err = r.WorkerGWSidecarClient.UpdateSliceQosProfile(ctx, sidecarGrpcAddress, slice)
 	if err != nil {
-		// log.Error(err, "Failed to send qos to netop. PodIp: %v, PodName: %v", n.PodIP, n.PodName)
+		log.Error(err, "Failed to send qos to gateway")
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil, true
 	}
 

--- a/controllers/slicegateway/types.go
+++ b/controllers/slicegateway/types.go
@@ -42,6 +42,7 @@ type HubClientProvider interface {
 type WorkerGWSidecarClientProvider interface {
 	GetStatus(ctx context.Context, serverAddr string) (*gwsidecar.GwStatus, error)
 	SendConnectionContext(ctx context.Context, serverAddr string, gwConnCtx *gwsidecar.GwConnectionContext) error
+	UpdateSliceQosProfile(ctx context.Context, serverAddr string, slice *kubeslicev1beta1.Slice) error
 }
 
 type WorkerRouterClientProvider interface {

--- a/tests/emulator/workerclient/sidecargw/client.go
+++ b/tests/emulator/workerclient/sidecargw/client.go
@@ -3,6 +3,7 @@ package sidecargw
 import (
 	"context"
 
+	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/pkg/gwsidecar"
 	"github.com/stretchr/testify/mock"
 )
@@ -22,5 +23,9 @@ func (ClientEmulator *ClientEmulator) GetStatus(
 }
 
 func (ClientEmulator *ClientEmulator) SendConnectionContext(ctx context.Context, serverAddr string, gwConnCtx *gwsidecar.GwConnectionContext) error {
+	return nil
+}
+
+func (ClientEmulator *ClientEmulator) UpdateSliceQosProfile(ctx context.Context, serverAddr string, slice *kubeslicev1beta1.Slice) error {
 	return nil
 }


### PR DESCRIPTION
Slice Operator changes to send TC config to VPN sidecar