### PR TITLE
Rename deploy webhook package name to pod

### DIFF
--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -17,8 +17,8 @@
  */
 
 // Package v1beta1 contains API Schema definitions for the mesh v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=networking.kubeslice.io
+// +kubebuilder:object:generate=true
+// +groupName=networking.kubeslice.io
 package v1beta1
 
 import (

--- a/controllers/slice/app_pod.go
+++ b/controllers/slice/app_pod.go
@@ -25,7 +25,7 @@ import (
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/controllers"
 	"github.com/kubeslice/worker-operator/pkg/logger"
-	webhook "github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -24,7 +24,7 @@ import (
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/controllers"
 	"github.com/kubeslice/worker-operator/pkg/logger"
-	webhook "github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"

--- a/controllers/slice/slicerouter.go
+++ b/controllers/slice/slicerouter.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/kubeslice/worker-operator/controllers"
 	"github.com/kubeslice/worker-operator/pkg/logger"
-	webhook "github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	webhook "github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/controllers/slicegateway/slicegateway.go
+++ b/controllers/slicegateway/slicegateway.go
@@ -41,7 +41,7 @@ import (
 	"github.com/kubeslice/worker-operator/pkg/gwsidecar"
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	"github.com/kubeslice/worker-operator/pkg/router"
-	webhook "github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ import (
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	"github.com/kubeslice/worker-operator/pkg/networkpolicy"
 	"github.com/kubeslice/worker-operator/pkg/utils"
-	deploywh "github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	podwh "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -109,9 +109,9 @@ func main() {
 	// Use an environment variable to be able to disable webhooks, so that we can run the operator locally
 	if utils.GetEnvOrDefault("ENABLE_WEBHOOKS", "true") == "true" {
 		mgr.GetWebhookServer().Register("/mutate-corev1-pod", &webhook.Admission{
-			Handler: &deploywh.WebhookServer{
+			Handler: &podwh.WebhookServer{
 				Client:          mgr.GetClient(),
-				SliceInfoClient: deploywh.NewWebhookClient(),
+				SliceInfoClient: podwh.NewWebhookClient(),
 			},
 		})
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -36,7 +36,7 @@ type Cluster struct {
 	Name   string `json:"clusterName,omitempty"`
 }
 
-//NewCluster returns ClusterInterface
+// NewCluster returns ClusterInterface
 func NewCluster(client client.Client, clusterName string) ClusterInterface {
 	return &Cluster{
 		Client: client,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -49,12 +49,12 @@ func init() {
 	}
 }
 
-//WithLogger takes in a context and returns a context with key as loggerKey{} and value as loggger(of type logr.Logger) passed
+// WithLogger takes in a context and returns a context with key as loggerKey{} and value as loggger(of type logr.Logger) passed
 func WithLogger(ctx context.Context, logger logr.Logger) context.Context {
 	return context.WithValue(ctx, loggerKey{}, logger)
 }
 
-//FromContext returns a logger from the context.
+// FromContext returns a logger from the context.
 func FromContext(ctx context.Context) logr.Logger {
 
 	if v, ok := ctx.Value(loggerKey{}).(logr.Logger); ok {
@@ -64,7 +64,7 @@ func FromContext(ctx context.Context) logr.Logger {
 	return NewLogger()
 }
 
-//NewLogger Creates a new logr.Logger
+// NewLogger Creates a new logr.Logger
 func NewLogger() logr.Logger {
 
 	// info and debug level enabler

--- a/pkg/manifest/egress.go
+++ b/pkg/manifest/egress.go
@@ -34,12 +34,13 @@ import (
 
 // Install istio egress gw resources on the given cluster in a slice
 // Resources:
-//  deployment (adds annotations to add the egress pod to the slice)
-//  serviceaccount
-//  role
-//  rolebinding
-//  service (type clusterip)
-//  gateway
+//
+//	deployment (adds annotations to add the egress pod to the slice)
+//	serviceaccount
+//	role
+//	rolebinding
+//	service (type clusterip)
+//	gateway
 func InstallEgress(ctx context.Context, c client.Client, slice *kubeslicev1beta1.Slice) error {
 	sliceName := slice.Name
 
@@ -107,12 +108,13 @@ func InstallEgress(ctx context.Context, c client.Client, slice *kubeslicev1beta1
 
 // Uninstall istio egress (EW) resources fo a slice from a given cluster
 // Resources:
-//  deployment
-//  serviceaccount
-//  role
-//  rolebinding
-//  service
-//  gateway
+//
+//	deployment
+//	serviceaccount
+//	role
+//	rolebinding
+//	service
+//	gateway
 func UninstallEgress(ctx context.Context, c client.Client, sliceName string) error {
 
 	log.Info("deleting EW egress gw for the slice", "slice", sliceName)

--- a/pkg/manifest/ingress.go
+++ b/pkg/manifest/ingress.go
@@ -34,11 +34,12 @@ import (
 
 // Install istio ingress gw resources on the given cluster in a slice
 // Resources:
-//  deployment (adds annotations to add the ingress pod to the slice)
-//  serviceaccount
-//  role
-//  rolebinding
-//  service (type clusterip)
+//
+//	deployment (adds annotations to add the ingress pod to the slice)
+//	serviceaccount
+//	role
+//	rolebinding
+//	service (type clusterip)
 func InstallIngress(ctx context.Context, c client.Client, slice *kubeslicev1beta1.Slice) error {
 	sliceName := slice.Name
 
@@ -105,11 +106,12 @@ func InstallIngress(ctx context.Context, c client.Client, slice *kubeslicev1beta
 
 // Uninstall istio ingress (EW) resources fo a slice from a given cluster
 // Resources:
-//  deployment
-//  serviceaccount
-//  role
-//  rolebinding
-//  service
+//
+//	deployment
+//	serviceaccount
+//	role
+//	rolebinding
+//	service
 func UninstallIngress(ctx context.Context, c client.Client, slice string) error {
 	// TODO objects should be unique to slice
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -89,7 +89,7 @@ func Float64frombytes(bytes []byte) float64 {
 	return float
 }
 
-//method to register metrics to prometheus
+// method to register metrics to prometheus
 func init() {
 	// Register custom metrics with the global prometheus registry
 	monitoring.MustRegister(

--- a/pkg/webhook/pod/pod_suite_test.go
+++ b/pkg/webhook/pod/pod_suite_test.go
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package deploy_test
+package pod_test
 
 import (
 	"testing"

--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package deploy
+package pod
 
 import (
 	"context"

--- a/pkg/webhook/pod/webhook_test.go
+++ b/pkg/webhook/pod/webhook_test.go
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-package deploy_test
+package pod_test
 
 import (
 	"context"

--- a/pkg/webhook/pod/webhook_test.go
+++ b/pkg/webhook/pod/webhook_test.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kubeslice/worker-operator/controllers"
-	"github.com/kubeslice/worker-operator/pkg/webhook/deploy"
+	"github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,7 +45,7 @@ func (f fakeWebhookClient) GetNamespaceLabels(ctx context.Context, client client
 
 var _ = Describe("Deploy Webhook", func() {
 	fakeWhClient := new(fakeWebhookClient)
-	webhookServer := deploy.WebhookServer{
+	webhookServer := pod.WebhookServer{
 		SliceInfoClient: fakeWhClient,
 	}
 	Describe("MutationRequired", func() {
@@ -61,14 +61,14 @@ var _ = Describe("Deploy Webhook", func() {
 				{
 					Annotations: map[string]string{
 						controllers.ApplicationNamespaceSelectorLabelKey: "green",
-						deploy.AdmissionWebhookAnnotationStatusKey:       "",
+						pod.AdmissionWebhookAnnotationStatusKey:          "",
 					}, // with empty value for status key
 					Namespace: "test-ns",
 				},
 				{
 					Annotations: map[string]string{
 						controllers.ApplicationNamespaceSelectorLabelKey: "green",
-						deploy.AdmissionWebhookAnnotationStatusKey:       "not injected",
+						pod.AdmissionWebhookAnnotationStatusKey:          "not injected",
 					}, // with different value for status key
 					Namespace: "test-ns",
 				},
@@ -89,7 +89,7 @@ var _ = Describe("Deploy Webhook", func() {
 			table := []metav1.ObjectMeta{
 				{
 					Annotations: map[string]string{
-						deploy.AdmissionWebhookAnnotationStatusKey: "injected",
+						pod.AdmissionWebhookAnnotationStatusKey: "injected",
 					}, // with injection status
 					Namespace: "test-ns",
 				},

--- a/pkg/webhook/pod/webhook_utils.go
+++ b/pkg/webhook/pod/webhook_utils.go
@@ -1,4 +1,4 @@
-package deploy
+package pod
 
 import (
 	"context"


### PR DESCRIPTION
Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>

Recently the webhook was modified to mutate pods instead of deployments. The package name and variable names were still using the word "deploy". This PR fixes this to improve code readability.

note: the spacing changes are from `go fmt`