### PR TITLE
add a new label to application ns and kubeslice-system ns to make nsm webhook fault tolerant

### DIFF
--- a/controllers/slice/consts.go
+++ b/controllers/slice/consts.go
@@ -5,4 +5,5 @@ const (
 	AllowedNamespaceSelectorLabelKey     = "kubeslice.io/namespace"
 	ApplicationNamespaceSelectorLabelKey = "kubeslice.io/slice"
 	AllowedNamespaceAnnotationKey        = "kubeslice.io/trafficAllowedToSlices"
+	InjectSidecarKey                     = "kubeslice.io/inject"
 )

--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -590,6 +590,7 @@ func (r *SliceReconciler) labelAppNamespaces(ctx context.Context, cfgAppNsList [
 			nsLabels = make(map[string]string)
 		}
 		nsLabels[controllers.ApplicationNamespaceSelectorLabelKey] = slice.Name
+		nsLabels[InjectSidecarKey] = "true"
 		namespace.ObjectMeta.SetLabels(nsLabels)
 
 		err = r.Update(ctx, namespace)

--- a/controllers/slice/reconciler.go
+++ b/controllers/slice/reconciler.go
@@ -96,6 +96,28 @@ func (r *SliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 	log.Info("reconciling", "slice", slice.Name)
 
+	// label kubeslice-system namespace with kubeslice.io/inject=true label
+	namespace := &corev1.Namespace{}
+	err = r.Get(ctx, types.NamespacedName{Name: "kubeslice-system"}, namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	// A namespace might not have any labels attached to it. Directly accessing the label map
+	// leads to a crash for such namespaces.
+	// If the label map is nil, create one and use the setter api to attach it to the namespace.
+	nsLabels := namespace.ObjectMeta.GetLabels()
+	if nsLabels == nil {
+		nsLabels = make(map[string]string)
+	}
+	if _, ok := nsLabels[InjectSidecarKey]; !ok {
+		nsLabels[InjectSidecarKey] = "true"
+		namespace.ObjectMeta.SetLabels(nsLabels)
+
+		err = r.Update(ctx, namespace)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	// Examine DeletionTimestamp to determine if object is under deletion
 	// The object is not being deleted, so if it does not have our finalizer,
 	// then lets add the finalizer and update the object. This is equivalent


### PR DESCRIPTION
This PR adds a new label kubeslice.io/inject=true to application namespaces and specifically to kubeslice-system namespace after a slice is created.
We will use this label in nsm mutatingwebhookconfig in namespace selector. This way only requests from application namespaces and kubeslice-system(gw pods) goes to nsm webhook