### PR TITLE
Introduce standard log fields and expose zap.SugaredLogger

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	log                        logr.Logger = logger.NewLogger()
+	log                        logr.Logger = logger.NewWrappedLogger()
 	allowedNamespacesByDefault             = []string{"kubeslice-system", "kube-system", "istio-system"}
 )
 

--- a/controllers/serviceexport/istio_serviceentry.go
+++ b/controllers/serviceexport/istio_serviceentry.go
@@ -111,7 +111,7 @@ func getServiceEntries(ctx context.Context, r client.Reader, serviceexport *kube
 }
 
 // Create serviceEntry based on serviceExport endpoint spec
-func  (r *Reconciler )createServiceEntryForEndpoint(serviceexport *kubeslicev1beta1.ServiceExport, endpoint *kubeslicev1beta1.ServicePod) *istiov1beta1.ServiceEntry {
+func (r *Reconciler) createServiceEntryForEndpoint(serviceexport *kubeslicev1beta1.ServiceExport, endpoint *kubeslicev1beta1.ServicePod) *istiov1beta1.ServiceEntry {
 	ports := []*networkingv1beta1.Port{}
 
 	for _, p := range serviceexport.Spec.Ports {

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(logger.NewLogger())
+	ctrl.SetLogger(logger.NewWrappedLogger())
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,

--- a/pkg/cluster/node.go
+++ b/pkg/cluster/node.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var log = logger.NewLogger().WithValues("type", "hub")
+var log = logger.NewWrappedLogger().WithValues("type", "hub")
 
 var nodeInfo *NodeInfo
 

--- a/pkg/hub/hubclient/hubclient.go
+++ b/pkg/hub/hubclient/hubclient.go
@@ -50,7 +50,7 @@ const (
 )
 
 var scheme = runtime.NewScheme()
-var log = logger.NewLogger().WithValues("type", "hub")
+var log = logger.NewWrappedLogger().WithValues("type", "hub")
 
 func init() {
 	clientgoscheme.AddToScheme(scheme)

--- a/pkg/hub/manager/manager.go
+++ b/pkg/hub/manager/manager.go
@@ -43,7 +43,7 @@ import (
 var scheme = runtime.NewScheme()
 
 func init() {
-	log.SetLogger(logger.NewLogger())
+	log.SetLogger(logger.NewWrappedLogger())
 	clientgoscheme.AddToScheme(scheme)
 	utilruntime.Must(spokev1alpha1.AddToScheme(scheme))
 	utilruntime.Must(kubeslicev1beta1.AddToScheme(scheme))

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -68,14 +68,15 @@ func FromContext(ctx context.Context) logr.Logger {
 }
 
 // Creates a new zap logger, wraps it to logr.Logger using zapr
-// and returns the wrapped logger
+// Required for controller-runtime logging
 func NewWrappedLogger() logr.Logger {
 	logger := NewLogger()
 
 	return zapr.NewLogger(logger.Desugar())
 }
 
-// NewLogger Creates a new SugaredLogger instance with predefined fields
+// NewLogger Creates a new SugaredLogger instance with predefined standard fields
+// SugaredLogger makes it easy to use structured logging with logging levels and additional fields
 func NewLogger() *uzap.SugaredLogger {
 
 	// info and debug level enabler

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -115,5 +115,5 @@ func NewLogger() *uzap.SugaredLogger {
 	// finally construct the logger with the tee core
 	logger := uzap.New(core).Sugar()
 
-	return logger.With("namespace", ControlPlaneNamespace, "cluster", ClusterName)
+	return logger.With("namespace", ControlPlaneNamespace, "sliceCluster", ClusterName)
 }

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -30,7 +30,7 @@ import (
 	"github.com/kubeslice/worker-operator/pkg/logger"
 )
 
-var log = logger.NewLogger()
+var log = logger.NewWrappedLogger()
 
 func GetManifestPath(file string) string {
 	dir := os.Getenv("MANIFEST_PATH")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 Declaration of each metric
 */
 var (
-	metricLog = logger.NewLogger().WithValues("type", "metrics")
+	metricLog = logger.NewWrappedLogger().WithValues("type", "metrics")
 	// appPodsGauge is a prometheus metric which is a gauge of no. of app pods.
 	appPodsGauge = monitoring.NewGauge(
 		"kubeslice_slice_app_pods",

--- a/pkg/monitoring/monitoring.go
+++ b/pkg/monitoring/monitoring.go
@@ -38,7 +38,7 @@ import (
 type Unit string
 
 var (
-	log = logger.NewLogger().WithValues("type", "monitoring")
+	log = logger.NewWrappedLogger().WithValues("type", "monitoring")
 )
 
 // Predefined units for use with the monitoring package.

--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	log = logger.NewLogger().WithName("Webhook").V(1)
+	log = logger.NewWrappedLogger().WithName("Webhook").V(1)
 )
 
 type SliceInfoProvider interface {

--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var log = logger.NewLogger()
+var log = logger.NewWrappedLogger()
 
 var _ = Describe("SliceController", func() {
 


### PR DESCRIPTION
To introduce standard logging fields and conventions, we need to fix the following limitations with the current codebase

* `go-logr` logr.logger interface doesn't support log levels (they use verbose level number instead). 
* Top level fields (ts, msg etc) are not as per google structured logging standard. This makes it difficult to view the logs in google console. https://cloud.google.com/logging/docs/structured-logging

To fix this, this PR introduces the following changes (more PRs to follow)

* Add standard logging fields `namespace` and `sliceCluster`
* Change log field names
  * level -> severity
  * msg -> message
  * ts -> timestamp 
* Expose SugaredLogger from zap to use warn and debug levels directly
* Rename `NewLogger` to `NewWrappedLogger` and expose SugaredLogger under `NewLogger`
* Replace setupLog in main.go to use sugaredLogger (as an example)

Next steps

* Gradually replace `logr.Logger` with `uzap.SugaredLogger` in all our packages
* Improve log messages and fields