### PR TITLE
[WIP] Add support for 1.24+

### DIFF
--- a/tests/spoke/cluster_info_test.go
+++ b/tests/spoke/cluster_info_test.go
@@ -155,7 +155,7 @@ prefixes:
 				return err == nil
 			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
 
-			err := hub.PostCredsToHub(ctx, k8sClient, k8sClient, operatorSecret)
+			err := hub.PostCredsToHub(ctx, k8sClient, operatorSecret.Data["token"], operatorSecret.Data["ca.crt"])
 			Expect(err).To(BeNil())
 
 			//get the secret on controller


### PR DESCRIPTION
Signed-off-by: Jayadeep KM <kmjayadeep@gmail.com>

Adding support for k8s 1.24

Major changes

* Service account token for dashboard is created using tokenrequest api. Due to this [change](https://itnext.io/big-change-in-k8s-1-24-about-serviceaccounts-and-their-secrets-4b909a4af4e0)
* Use the ca cert from `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` to populate the secret in hub since we don't have a secret for serviceaccount anymore

TODO:
- [ ] add some test cases (currently there are no tests for these methods)
- [ ] test in 1.25
- [ ] test in <1.20 (for backward compatibility)