### PR TITLE
feat(AM-5509): Namespace sameness on a slice 

### DIFF
--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -103,7 +103,7 @@ func (r *SliceReconciler) reconcileAppNamespaces(ctx context.Context, slice *kub
 	// (In case it doesn't exist, first create it & then label the same)
 	// If a namespace is found in the existing list, mark it to indicate that it has been verified
 	// to be valid as it is present in the configured list as well.
-	labeledAppNsList, statusChanged, err := r.labelAppNamespaces(ctx, cfgAppNsList, existingAppNsMap, slice)
+	labeledAppNsList, statusChanged, err := r.createAndLabelAppNamespaces(ctx, cfgAppNsList, existingAppNsMap, slice)
 	if err != nil {
 		return ctrl.Result{}, err, true
 	}
@@ -706,7 +706,7 @@ func buildAppNamespacesList(slice *kubeslicev1beta1.Slice) []string {
 	}
 	return cfgAppNsList
 }
-func (r *SliceReconciler) labelAppNamespaces(ctx context.Context, cfgAppNsList []string, existingAppNsMap map[string]*nsMarker, slice *kubeslicev1beta1.Slice) ([]string, bool, error) {
+func (r *SliceReconciler) createAndLabelAppNamespaces(ctx context.Context, cfgAppNsList []string, existingAppNsMap map[string]*nsMarker, slice *kubeslicev1beta1.Slice) ([]string, bool, error) {
 	labeledAppNsList := []string{}
 	statusChanged := false
 	log := logger.FromContext(ctx).WithValues("type", "appNamespaces")
@@ -729,7 +729,8 @@ func (r *SliceReconciler) labelAppNamespaces(ctx context.Context, cfgAppNsList [
 			}
 			err2 := r.Create(ctx, namespace)
 			if err2 != nil {
-				log.Error(err2, "Failed to create namespace", cfgAppNs)
+				log.Error(err2, "Failed to create namespace", "namespace", cfgAppNs)
+				continue
 			}
 			log.Info("Namespace created successfully", "namespace", cfgAppNs)
 		}

--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -733,9 +733,10 @@ func (r *SliceReconciler) createAndLabelAppNamespaces(ctx context.Context, cfgAp
 					continue
 				}
 				log.Info("Namespace created successfully", "namespace", cfgAppNs)
+			} else {
+				log.Error(err, "Failed to get namespace", "namespace", cfgAppNs)
+				continue
 			}
-			log.Error(err, "Failed to get namespace", "namespace", cfgAppNs)
-			continue
 		}
 		// A namespace might not have any labels attached to it. Directly accessing the label map
 		// leads to a crash for such namespaces.

--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -730,6 +730,7 @@ func (r *SliceReconciler) createAndLabelAppNamespaces(ctx context.Context, cfgAp
 				}
 				if err := r.Create(ctx, namespace); err != nil {
 					log.Error(err, "Failed to create namespace", "namespace", cfgAppNs)
+					// if unable to create move to next NS in your list
 					continue
 				}
 				log.Info("Namespace created successfully", "namespace", cfgAppNs)

--- a/tests/spoke/namespace_sameness_test.go
+++ b/tests/spoke/namespace_sameness_test.go
@@ -1,0 +1,155 @@
+package spoke_test
+
+import (
+	"context"
+
+	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
+	"github.com/kubeslice/worker-operator/controllers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+)
+
+var _ = Describe("SliceNetpol", func() {
+	var slice *kubeslicev1beta1.Slice
+	var createdSlice *kubeslicev1beta1.Slice
+	var appNs *corev1.Namespace
+
+	When("Slice CR is created with application namespaces specified,", func() {
+		BeforeEach(func() {
+			// Prepare k8s objects for slice and kubeslice-dns service
+			slice = &kubeslicev1beta1.Slice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-slice",
+					Namespace: "kubeslice-system",
+				},
+				Spec: kubeslicev1beta1.SliceSpec{},
+			}
+
+			appNs = &corev1.Namespace{}
+
+			createdSlice = &kubeslicev1beta1.Slice{}
+			// Cleanup after each test
+			DeferCleanup(func() {
+				ctx := context.Background()
+				Expect(k8sClient.Delete(ctx, slice)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: slice.Name, Namespace: slice.Namespace}, slice)
+					return errors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue())
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-appns"}, appNs); err != nil {
+					Expect(k8sClient.Delete(ctx, appNs)).Should(Succeed())
+				}
+			})
+		})
+
+		It("should create & label app ns if it's not present in specified cluster", func() {
+			// create slice
+			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
+			// eventually slice comes up
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "test-slice",
+					Namespace: "kubeslice-system",
+				}, createdSlice)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+			// onboard app ns
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "test-slice",
+					Namespace: "kubeslice-system",
+				}, createdSlice)
+				if err != nil {
+					return err
+				}
+				createdSlice.Status.SliceConfig = &kubeslicev1beta1.SliceConfig{
+					NamespaceIsolationProfile: &kubeslicev1beta1.NamespaceIsolationProfile{
+						ApplicationNamespaces: []string{
+							"test-appns",
+						},
+					},
+				}
+				err = k8sClient.Status().Update(ctx, createdSlice)
+				return err
+			})
+			Expect(err).ToNot(HaveOccurred())
+			// namespace should get created and labeled
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-appns"}, appNs)
+				if err != nil {
+					return false
+				}
+				labels := appNs.ObjectMeta.GetLabels()
+				if labels == nil {
+					return false
+				}
+				sliceLabel, ok := labels[controllers.ApplicationNamespaceSelectorLabelKey]
+				if !ok {
+					return false
+				}
+				Expect(sliceLabel).To(Equal(slice.Name))
+				return true
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		When("A mix of valid & invalid app NS specified in sliceconfig,", func() {
+			It("should create & label all valid app ns", func() {
+				// create slice
+				Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
+				// eventually slice comes up
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      "test-slice",
+						Namespace: "kubeslice-system",
+					}, createdSlice)
+					return err == nil
+				}, timeout, interval).Should(BeTrue())
+				// onboard app ns
+				err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Name:      "test-slice",
+						Namespace: "kubeslice-system",
+					}, createdSlice)
+					if err != nil {
+						return err
+					}
+					createdSlice.Status.SliceConfig = &kubeslicev1beta1.SliceConfig{
+						NamespaceIsolationProfile: &kubeslicev1beta1.NamespaceIsolationProfile{
+							ApplicationNamespaces: []string{
+								"test-appNS", // must be a lowercase RFC 1123 label
+								"test-appns",
+							},
+						},
+					}
+					err = k8sClient.Status().Update(ctx, createdSlice)
+					return err
+				})
+				Expect(err).ToNot(HaveOccurred())
+				// namespace should get created and labeled
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: "test-appns"}, appNs)
+					if err != nil {
+						return false
+					}
+					labels := appNs.ObjectMeta.GetLabels()
+					if labels == nil {
+						return false
+					}
+					sliceLabel, ok := labels[controllers.ApplicationNamespaceSelectorLabelKey]
+					if !ok {
+						return false
+					}
+					Expect(sliceLabel).To(Equal(slice.Name))
+					return true
+				}, timeout, interval).Should(BeTrue())
+			})
+
+		})
+
+	})
+})


### PR DESCRIPTION
- Creating a namespace if that particular namespace is not available in the any cluster which is part of the slice. 
- Prior to this edit, operator reconciler used to throw error, but waited for namespace to be created by user.
