### PR TITLE
feat(): Slice Health Status

### DIFF
--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -335,7 +335,6 @@ func (r *SliceReconciler) updateSliceHealth(ctx context.Context, slice *spokev1a
 			if cs.ComponentHealthStatus != spokev1alpha1.ComponentHealthStatusNormal {
 				slice.Status.SliceHealth.SliceHealthStatus = spokev1alpha1.SliceHealthStatusWarning
 			}
-			log.Info("component ", c.name, " status ", cs.ComponentHealthStatus)
 		}
 	}
 	return nil
@@ -360,7 +359,7 @@ func (r *SliceReconciler) getComponentStatus(ctx context.Context, c *component) 
 		return nil, nil
 	}
 	if len(pods) == 0 {
-		log.Error(fmt.Errorf("no pods running"), "unhealthy pod", c.name)
+		log.Error(fmt.Errorf("no pods running"), "unhealthy", "pod", c.name)
 		cs.ComponentHealthStatus = spokev1alpha1.ComponentHealthStatusError
 		return cs, nil
 	}

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -335,7 +335,7 @@ func (r *SliceReconciler) updateSliceHealth(ctx context.Context, slice *spokev1a
 			if cs.ComponentHealthStatus != spokev1alpha1.ComponentHealthStatusNormal {
 				slice.Status.SliceHealth.SliceHealthStatus = spokev1alpha1.SliceHealthStatusWarning
 			}
-			log.Info("GOURISH", "component ", c.name, " status ", cs.ComponentHealthStatus)
+			log.Info("component ", c.name, " status ", cs.ComponentHealthStatus)
 		}
 	}
 	return nil

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -20,12 +20,15 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	spokev1alpha1 "github.com/kubeslice/apis/pkg/worker/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/pkg/events"
 	"github.com/kubeslice/worker-operator/pkg/logger"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -33,6 +36,57 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+const (
+	ReconcileInterval = 10 * time.Second
+)
+
+type component struct {
+	name          string
+	labels        map[string]string
+	ns            string
+	ignoreMissing bool
+}
+
+var components = []component{
+	{
+		name: "dns",
+		labels: map[string]string{
+			"app": "kubeslice-dns",
+		},
+		ns: ControlPlaneNamespace,
+	},
+	{
+		name: "slicegateway",
+		labels: map[string]string{
+			"kubeslice.io/pod-type": "slicegateway",
+		},
+		ns: ControlPlaneNamespace,
+	},
+	{
+		name: "slicerouter",
+		labels: map[string]string{
+			"kubeslice.io/pod-type": "router",
+		},
+		ns: ControlPlaneNamespace,
+	},
+	{
+		name: "egress",
+		labels: map[string]string{
+			"istio": "egressgateway",
+		},
+		ns:            ControlPlaneNamespace,
+		ignoreMissing: true,
+	},
+	{
+		name: "ingress",
+		labels: map[string]string{
+			"istio": "ingressgateway",
+		},
+		ns:            ControlPlaneNamespace,
+		ignoreMissing: true,
+	},
+}
 
 type SliceReconciler struct {
 	client.Client
@@ -126,8 +180,21 @@ func (r *SliceReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 		log.Error(err, "unable to update slice status in spoke cluster", "slice", meshSlice)
 		return reconcile.Result{}, err
 	}
-
-	return reconcile.Result{}, nil
+	if slice.Status.SliceHealth == nil {
+		slice.Status.SliceHealth = &spokev1alpha1.SliceHealth{}
+	}
+	err = r.updateSliceHealth(ctx, slice)
+	if err != nil {
+		log.Error(err, "unable to update slice health status in hub cluster", "workerSlice", slice)
+		return reconcile.Result{}, err
+	}
+	slice.Status.SliceHealth.LastUpdated = metav1.Now()
+	if err := r.Status().Update(ctx, slice); err != nil {
+		log.Error(err, "unable to update slice CR")
+	} else {
+		log.Info("succesfully updated the slice CR ", "slice CR ", slice)
+	}
+	return reconcile.Result{RequeueAfter: ReconcileInterval}, nil
 }
 
 func (r *SliceReconciler) updateSliceConfig(ctx context.Context, meshSlice *kubeslicev1beta1.Slice, spokeSlice *spokev1alpha1.WorkerSliceConfig) error {
@@ -252,4 +319,58 @@ func (r *SliceReconciler) handleSliceDeletion(slice *spokev1alpha1.WorkerSliceCo
 		return true, reconcile.Result{}, nil
 	}
 	return false, reconcile.Result{}, nil
+}
+
+func (r *SliceReconciler) updateSliceHealth(ctx context.Context, slice *spokev1alpha1.WorkerSliceConfig) error {
+	log := logger.FromContext(ctx)
+	slice.Status.SliceHealth.ComponentStatuses = []spokev1alpha1.ComponentStatus{}
+	slice.Status.SliceHealth.SliceHealthStatus = spokev1alpha1.ComponentHealthStatusNormal
+	for _, c := range components {
+		cs, err := r.getComponentStatus(ctx, &c)
+		if err != nil {
+			log.Error(err, "unable to fetch component status")
+		}
+		if cs != nil {
+			slice.Status.SliceHealth.ComponentStatuses = append(slice.Status.SliceHealth.ComponentStatuses, *cs)
+			if cs.ComponentHealthStatus != spokev1alpha1.ComponentHealthStatusNormal {
+				slice.Status.SliceHealth.SliceHealthStatus = spokev1alpha1.SliceHealthStatusWarning
+			}
+			log.Info("GOURISH", "component ", c.name, " status ", cs.ComponentHealthStatus)
+		}
+	}
+	return nil
+}
+
+func (r *SliceReconciler) getComponentStatus(ctx context.Context, c *component) (*spokev1alpha1.ComponentStatus, error) {
+	log := logger.FromContext(ctx)
+	podList := &corev1.PodList{}
+	listOpts := []client.ListOption{
+		client.MatchingLabels(c.labels),
+		client.InNamespace(c.ns),
+	}
+	if err := r.MeshClient.List(ctx, podList, listOpts...); err != nil {
+		log.Error(err, "Failed to list pods", "pod", c.name)
+		return nil, err
+	}
+	pods := podList.Items
+	cs := &spokev1alpha1.ComponentStatus{
+		Component: c.name,
+	}
+	if len(pods) == 0 && c.ignoreMissing {
+		return nil, nil
+	}
+	if len(pods) == 0 {
+		log.Error(fmt.Errorf("no pods running"), "unhealthy pod", c.name)
+		cs.ComponentHealthStatus = spokev1alpha1.ComponentHealthStatusError
+		return cs, nil
+	}
+	for _, pod := range pods {
+		if pod.Status.Phase != corev1.PodRunning {
+			log.Info("pod is not healthy", "component", c.name)
+			cs.ComponentHealthStatus = spokev1alpha1.ComponentHealthStatusError
+			return cs, nil
+		}
+	}
+	cs.ComponentHealthStatus = spokev1alpha1.ComponentHealthStatusNormal
+	return cs, nil
 }

--- a/tests/files/crd/spoke.kubeslice.io_spokesliceconfigs.yaml
+++ b/tests/files/crd/spoke.kubeslice.io_spokesliceconfigs.yaml
@@ -167,6 +167,41 @@ spec:
                       type: string
                   type: object
                 type: array
+              sliceHealth:
+                description: SliceHealth shows the health of the slice in worker cluster
+                properties:
+                  componentStatuses:
+                    description: ComponentStatuses shows the health status of individual
+                      components in the cluster
+                    items:
+                      properties:
+                        component:
+                          description: Component name
+                          type: string
+                        componentHealthStatus:
+                          enum:
+                          - Normal
+                          - Warning
+                          - Error
+                          type: string
+                      required:
+                      - component
+                      - componentHealthStatus
+                      type: object
+                    type: array
+                  lastUpdated:
+                    description: LastUpdated is the timestamp when healthstatus was
+                      updated
+                    format: date-time
+                    type: string
+                  sliceHealthStatus:
+                    description: SliceHealthStatus shows the overall health status
+                      of the slice
+                    enum:
+                    - Normal
+                    - Warning
+                    type: string
+                type: object
             type: object
         type: object
     served: true

--- a/tests/hub/hub_suite_test.go
+++ b/tests/hub/hub_suite_test.go
@@ -161,6 +161,7 @@ var _ = BeforeSuite(func() {
 	serviceImportReconciler := &controllers.ServiceImportReconciler{
 		MeshClient:    k8sClient,
 		EventRecorder: testSvcimEventRecorder,
+		Client:        k8sClient,
 	}
 
 	err = builder.

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = FDescribe("Hub SliceController", func() {
+var _ = Describe("Hub SliceController", func() {
 
 	Context("With Slice CR created in hub", func() {
 
@@ -256,7 +256,7 @@ var _ = FDescribe("Hub SliceController", func() {
 
 	})
 
-	FContext("Slice health check", func() {
+	Context("Slice health check", func() {
 		var hubSlice *workerv1alpha1.WorkerSliceConfig
 		var pods []*corev1.Pod
 		var ipamOcter = 16


### PR DESCRIPTION
Slice Health status checks the status of the following components : dns, slicerouter, slicegateway, ingress, egress and updates the overall slicehealthstatus with either a _normal_ or _warning_ state. 

The state can be observed on the controller cluster by `kubectl get workersliceconfig <slicename-clustername> -o yaml` 