### PR TITLE
Serviceexport fixes

### DIFF
--- a/controllers/serviceexport/serviceexport.go
+++ b/controllers/serviceexport/serviceexport.go
@@ -94,6 +94,10 @@ func (r *Reconciler) getAppPods(ctx context.Context, serviceexport *kubeslicev1b
 		if pod.Status.Phase == corev1.PodRunning {
 			dnsName := pod.Name + "." + getClusterName() + "." + serviceexport.Name + "." + serviceexport.Namespace + ".svc.slice.local"
 			ip := getNsmIP(&pod, appPodsInSlice)
+			// Avoid adding pods with no nsmip (not part of slice yet)
+			if ip == "" {
+				continue
+			}
 			appPods = append(appPods, kubeslicev1beta1.ServicePod{
 				Name:    pod.Name,
 				NsmIP:   ip,

--- a/controllers/serviceexport/utils.go
+++ b/controllers/serviceexport/utils.go
@@ -120,3 +120,12 @@ func getServiceProtocol(se *kubeslicev1beta1.ServiceExport) kubeslicev1beta1.Ser
 	return kubeslicev1beta1.ServiceProtocolTCP
 
 }
+
+func arrayContainsString(a []string, s string) bool {
+	for _, i := range a {
+		if i == s {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/spoke/namespace_controller_test.go
+++ b/tests/spoke/namespace_controller_test.go
@@ -77,6 +77,9 @@ var _ = Describe("ClusterInfoUpdate", func() {
 			DeferCleanup(func() {
 				ctx := context.Background()
 				Expect(k8sClient.Delete(ctx, cluster)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, slice)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, applicationNS)).Should(Succeed())
 			})
 		})
 
@@ -135,7 +138,8 @@ var _ = Describe("ClusterInfoUpdate", func() {
 			DeferCleanup(func() {
 				ctx := context.Background()
 				k8sClient.Delete(ctx, cluster)
-
+				Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, applicationNS)).Should(Succeed())
 			})
 		})
 		It("Should not update cluster CR with namespace", func() {

--- a/tests/spoke/service_discovery_test.go
+++ b/tests/spoke/service_discovery_test.go
@@ -45,6 +45,94 @@ func getTestServiceExportPorts() []kubeslicev1beta1.ServicePort {
 }
 
 var _ = Describe("ServiceExportController", func() {
+	Context("With serviceexport on a ns which is not onboarded to slice", func() {
+		var slice *kubeslicev1beta1.Slice
+		var dnssvc *corev1.Service
+		var svcex *kubeslicev1beta1.ServiceExport
+
+		BeforeEach(func() {
+			slice = &kubeslicev1beta1.Slice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-slice-1",
+					Namespace: "kubeslice-system",
+				},
+				Spec: kubeslicev1beta1.SliceSpec{},
+			}
+
+			dnssvc = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kubeslice-dns",
+					Namespace: "kubeslice-system",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Port: 52,
+					}},
+				},
+			}
+
+			svcex = &kubeslicev1beta1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "iperf-server",
+					Namespace: "default",
+				},
+				Spec: kubeslicev1beta1.ServiceExportSpec{
+					Slice: "test-slice-1",
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "iperf"},
+					},
+					Ports: getTestServiceExportPorts(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, svcex)).Should(Succeed())
+
+			DeferCleanup(func() {
+				ctx := context.Background()
+				Expect(k8sClient.Delete(ctx, svcex)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: svcex.Name, Namespace: svcex.Namespace}, svcex)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
+				Expect(k8sClient.Delete(ctx, dnssvc)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: dnssvc.Name, Namespace: dnssvc.Namespace}, dnssvc)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+			})
+
+		})
+
+		It("Should have export status pending when app ns is not onboarded", func() {
+			svcKey := types.NamespacedName{Name: "iperf-server", Namespace: "default"}
+			createdSvcEx := &kubeslicev1beta1.ServiceExport{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, svcKey, createdSvcEx)
+				if err != nil {
+					return false
+				}
+				if createdSvcEx.Status.ExportStatus != kubeslicev1beta1.ExportStatusPending {
+					return false
+				}
+				return true
+			}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, svcKey, createdSvcEx)
+				if err != nil {
+					return false
+				}
+				if createdSvcEx.Status.ExportStatus != kubeslicev1beta1.ExportStatusPending {
+					return false
+				}
+				return true
+			}, time.Second*5, time.Millisecond*500).Should(BeTrue())
+		})
+
+	})
 
 	Context("With a service export CR object installed, verify service export CR is reconciled", func() {
 		var slice *kubeslicev1beta1.Slice
@@ -90,6 +178,12 @@ var _ = Describe("ServiceExportController", func() {
 			}
 			createdSlice = &kubeslicev1beta1.Slice{}
 
+			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
+
+			slice.Status.ApplicationNamespaces = []string{"default"}
+			Expect(k8sClient.Status().Update(ctx, slice)).Should(Succeed())
+
 			// Cleanup after each test
 			DeferCleanup(func() {
 				ctx := context.Background()
@@ -115,9 +209,6 @@ var _ = Describe("ServiceExportController", func() {
 		})
 
 		It("Should update service export status", func() {
-			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
-
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      slice.Name,
@@ -151,10 +242,6 @@ var _ = Describe("ServiceExportController", func() {
 		})
 
 		It("Should update service export ports", func() {
-			log.Info("Creating slice", "slice", slice)
-			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
-
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      slice.Name,
@@ -207,11 +294,6 @@ var _ = Describe("ServiceExportController", func() {
 
 		})
 		It("Should Add a slice label to service export", func() {
-			log.Info("Creating slice", "slice", slice)
-
-			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
-
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      slice.Name,
@@ -241,9 +323,6 @@ var _ = Describe("ServiceExportController", func() {
 		})
 
 		It("Should Generate Events", func() {
-			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
-
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := k8sClient.Get(ctx, types.NamespacedName{
 					Name:      slice.Name,

--- a/tests/spoke/service_discovery_test.go
+++ b/tests/spoke/service_discovery_test.go
@@ -101,6 +101,14 @@ var _ = Describe("ServiceExportController", func() {
 					err := k8sClient.Get(ctx, types.NamespacedName{Name: dnssvc.Name, Namespace: dnssvc.Namespace}, dnssvc)
 					return errors.IsNotFound(err)
 				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
+				Expect(k8sClient.Delete(ctx, slice)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: slice.Name, Namespace: slice.Namespace}, slice)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
+				log.Info("cleaned up after test")
 			})
 
 		})
@@ -293,6 +301,7 @@ var _ = Describe("ServiceExportController", func() {
 			}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 
 		})
+
 		It("Should Add a slice label to service export", func() {
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := k8sClient.Get(ctx, types.NamespacedName{

--- a/tests/spoke/service_discovery_test.go
+++ b/tests/spoke/service_discovery_test.go
@@ -189,12 +189,6 @@ var _ = Describe("ServiceExportController", func() {
 			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
 
-			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				slice.Status.ApplicationNamespaces = []string{"default"}
-				return k8sClient.Status().Update(ctx, slice)
-			})
-			Expect(err).To(BeNil())
-
 			// Cleanup after each test
 			DeferCleanup(func() {
 				ctx := context.Background()
@@ -229,6 +223,7 @@ var _ = Describe("ServiceExportController", func() {
 					return err
 				}
 				createdSlice.Status.SliceConfig = &kubeslicev1beta1.SliceConfig{}
+				createdSlice.Status.ApplicationNamespaces = []string{"default"}
 				return k8sClient.Status().Update(ctx, createdSlice)
 			})
 			Expect(err).To(BeNil())
@@ -262,6 +257,7 @@ var _ = Describe("ServiceExportController", func() {
 					return err
 				}
 				createdSlice.Status.SliceConfig = &kubeslicev1beta1.SliceConfig{}
+				createdSlice.Status.ApplicationNamespaces = []string{"default"}
 				return k8sClient.Status().Update(ctx, createdSlice)
 			})
 			Expect(err).To(BeNil())
@@ -315,6 +311,7 @@ var _ = Describe("ServiceExportController", func() {
 					return err
 				}
 				createdSlice.Status.SliceConfig = &kubeslicev1beta1.SliceConfig{}
+				createdSlice.Status.ApplicationNamespaces = []string{"default"}
 				return k8sClient.Status().Update(ctx, createdSlice)
 			})
 			Expect(err).To(BeNil())
@@ -344,6 +341,7 @@ var _ = Describe("ServiceExportController", func() {
 					return err
 				}
 				createdSlice.Status.SliceConfig = &kubeslicev1beta1.SliceConfig{}
+				createdSlice.Status.ApplicationNamespaces = []string{"default"}
 				return k8sClient.Status().Update(ctx, createdSlice)
 			})
 			Expect(err).To(BeNil())

--- a/tests/spoke/service_discovery_test.go
+++ b/tests/spoke/service_discovery_test.go
@@ -189,8 +189,11 @@ var _ = Describe("ServiceExportController", func() {
 			Expect(k8sClient.Create(ctx, dnssvc)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
 
-			slice.Status.ApplicationNamespaces = []string{"default"}
-			Expect(k8sClient.Status().Update(ctx, slice)).Should(Succeed())
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				slice.Status.ApplicationNamespaces = []string{"default"}
+				return k8sClient.Status().Update(ctx, slice)
+			})
+			Expect(err).To(BeNil())
 
 			// Cleanup after each test
 			DeferCleanup(func() {

--- a/tests/spoke/service_import_test.go
+++ b/tests/spoke/service_import_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -88,9 +89,29 @@ var _ = Describe("ServiceImportController", func() {
 			DeferCleanup(func() {
 				ctx := context.Background()
 				Expect(k8sClient.Delete(ctx, svcim)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: svcim.Name, Namespace: svcim.Namespace}, svcim)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
 				Expect(k8sClient.Delete(ctx, dnscm)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: dnscm.Name, Namespace: dnscm.Namespace}, dnscm)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
 				Expect(k8sClient.Delete(ctx, dnssvc)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: dnssvc.Name, Namespace: dnssvc.Namespace}, dnssvc)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
 				Expect(k8sClient.Delete(ctx, slice)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: slice.Name, Namespace: slice.Namespace}, slice)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
+
 			})
 		})
 

--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -210,7 +210,7 @@ var _ = Describe("SliceController", func() {
 			DeferCleanup(func() {
 				Expect(k8sClient.Delete(ctx, svc)).Should(Succeed())
 				Eventually(func() bool {
-					err := k8sClient.Get(ctx, types.NamespacedName{Name: slice.Name, Namespace: slice.Namespace}, slice)
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc)
 					return errors.IsNotFound(err)
 				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 			})

--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -78,6 +78,10 @@ var _ = Describe("SliceController", func() {
 					return errors.IsNotFound(err)
 				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 				Expect(k8sClient.Delete(ctx, svc)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 			})
 		})
 

--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -209,6 +209,10 @@ var _ = Describe("SliceController", func() {
 			}
 			DeferCleanup(func() {
 				Expect(k8sClient.Delete(ctx, svc)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: slice.Name, Namespace: slice.Namespace}, slice)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 			})
 		})
 

--- a/tests/spoke/slice_netpol_test.go
+++ b/tests/spoke/slice_netpol_test.go
@@ -70,6 +70,10 @@ var _ = Describe("SliceNetpol", func() {
 			DeferCleanup(func() {
 				ctx := context.Background()
 				Expect(k8sClient.Delete(ctx, svc)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc)
+					return errors.IsNotFound(err)
+				}, timeout, interval).Should(BeTrue())
 				Expect(k8sClient.Delete(ctx, slice)).Should(Succeed())
 				Eventually(func() bool {
 					err := k8sClient.Get(ctx, types.NamespacedName{Name: slice.Name, Namespace: slice.Namespace}, slice)

--- a/tests/spoke/slicegw_controller_test.go
+++ b/tests/spoke/slicegw_controller_test.go
@@ -163,6 +163,10 @@ var _ = Describe("Worker SlicegwController", func() {
 					return true
 				}, time.Second*40, time.Millisecond*250).Should(BeTrue())
 				Expect(k8sClient.Delete(ctx, svc)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, svc)
+					return errors.IsNotFound(err)
+				}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
* Avoid onboarding serviceexport when namespace is not part of slice
* Avoid onboarding pods which are not part of slice
* Avoid onboarding serviceexport when slice is not present
* Fix flaky tests which were causing checks to fail in this PR