### PR TITLE
fix(): Fixed interference of sliceHealthStatus

### DIFF
--- a/controllers/slice/reconciler.go
+++ b/controllers/slice/reconciler.go
@@ -328,7 +328,6 @@ func (r *SliceReconciler) handleDnsSvc(ctx context.Context, slice *kubeslicev1be
 			slice.Status.DNSIP = svc.Spec.ClusterIP
 			err := r.Status().Update(ctx, slice)
 			if err != nil {
-				log.Error(err, "Failed to update DNS IP in slice status,retrying...")
 				return err
 			}
 			return nil

--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -26,7 +26,7 @@ const (
 	AWS   string = "aws"
 	AZURE string = "azure"
 
-	ReconcileInterval = 60 * time.Second
+	ReconcileInterval = 120 * time.Second
 )
 
 type Reconciler struct {

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -349,8 +349,9 @@ func (r *SliceReconciler) getComponentStatus(ctx context.Context, c *component, 
 		}
 	}
 	podList := &corev1.PodList{}
+	labelSelector := metav1.LabelSelector{MatchLabels: c.labels}
 	listOpts := []client.ListOption{
-		client.MatchingLabels(c.labels),
+		client.MatchingLabels(labelSelector.MatchLabels),
 		client.InNamespace(c.ns),
 	}
 	if err := r.MeshClient.List(ctx, podList, listOpts...); err != nil {

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -339,7 +339,8 @@ func (r *SliceReconciler) updateSliceHealth(ctx context.Context, slice *spokev1a
 	slice.Status.SliceHealth.SliceHealthStatus = spokev1alpha1.ComponentHealthStatusNormal
 	originalName, err := getOriginalName(slice)
 	if err != nil {
-		return err
+		log.Info("Could not find original name, skipping updateSliceHealth....")
+		return nil
 	}
 	for _, c := range components {
 		cs, err := r.getComponentStatus(ctx, &c, originalName)

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	ReconcileInterval = 60 * time.Second
+	ReconcileInterval = 10 * time.Second
 )
 
 type component struct {
@@ -170,7 +170,7 @@ func (r *SliceReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 			}
 			log.Info("slice status updated in spoke cluster")
 
-			return reconcile.Result{RequeueAfter: ReconcileInterval}, nil
+			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
 	}
@@ -191,6 +191,7 @@ func (r *SliceReconciler) Reconcile(ctx context.Context, req reconcile.Request) 
 	slice.Status.SliceHealth.LastUpdated = metav1.Now()
 	if err := r.Status().Update(ctx, slice); err != nil {
 		log.Error(err, "unable to update slice CR")
+		return reconcile.Result{}, err
 	} else {
 		log.Info("succesfully updated the slice CR ", "slice CR ", slice)
 	}

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -326,7 +326,7 @@ func (r *SliceReconciler) updateSliceHealth(ctx context.Context, slice *spokev1a
 	slice.Status.SliceHealth.ComponentStatuses = []spokev1alpha1.ComponentStatus{}
 	slice.Status.SliceHealth.SliceHealthStatus = spokev1alpha1.ComponentHealthStatusNormal
 	for _, c := range components {
-		cs, err := r.getComponentStatus(ctx, &c)
+		cs, err := r.getComponentStatus(ctx, &c, slice.Name)
 		if err != nil {
 			log.Error(err, "unable to fetch component status")
 		}
@@ -340,8 +340,13 @@ func (r *SliceReconciler) updateSliceHealth(ctx context.Context, slice *spokev1a
 	return nil
 }
 
-func (r *SliceReconciler) getComponentStatus(ctx context.Context, c *component) (*spokev1alpha1.ComponentStatus, error) {
+func (r *SliceReconciler) getComponentStatus(ctx context.Context, c *component, sliceName string) (*spokev1alpha1.ComponentStatus, error) {
 	log := logger.FromContext(ctx)
+	for i := range components {
+		if components[i].name != "dns" {
+			components[i].labels["kubeslice.io/slice"] = sliceName
+		}
+	}
 	podList := &corev1.PodList{}
 	listOpts := []client.ListOption{
 		client.MatchingLabels(c.labels),

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -216,7 +216,10 @@ func (r *SliceReconciler) updateSliceConfig(ctx context.Context, meshSlice *kube
 		meshSlice.Status.SliceConfig.SliceSubnet = spokeSlice.Spec.SliceSubnet
 	}
 	if meshSlice.ObjectMeta.Labels == nil {
-		meshSlice.ObjectMeta.Labels = spokeSlice.ObjectMeta.Labels
+		meshSlice.ObjectMeta.Labels = make(map[string]string)
+		if spokeSlice.ObjectMeta.Labels != nil {
+			meshSlice.ObjectMeta.Labels = spokeSlice.ObjectMeta.Labels
+		}
 	}
 
 	if meshSlice.Status.SliceConfig.SliceIpam.IpamClusterOctet == 0 {

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -348,15 +348,23 @@ func (r *SliceReconciler) getComponentStatus(ctx context.Context, c *component, 
 			components[i].labels["kubeslice.io/slice"] = sliceName
 		}
 	}
+	for i := range components {
+		log.Info("GOURISH component ", "component.name", components[i].name, "component.labels", components[i].labels)
+	}
 	podList := &corev1.PodList{}
-	labelSelector := metav1.LabelSelector{MatchLabels: c.labels}
 	listOpts := []client.ListOption{
-		client.MatchingLabels(labelSelector.MatchLabels),
+		// &client.ListOptions{
+		// 	Namespace:     c.ns,
+		// 	LabelSelector: labels.SelectorFromSet(c.labels),
+		// },
+		client.MatchingLabels(c.labels),
 		client.InNamespace(c.ns),
 	}
 	if err := r.MeshClient.List(ctx, podList, listOpts...); err != nil {
 		log.Error(err, "Failed to list pods", "pod", c.name)
 		return nil, err
+	} else {
+		log.Info("GOURISH pods", "pods", podList.Items)
 	}
 	pods := podList.Items
 	cs := &spokev1alpha1.ComponentStatus{

--- a/pkg/hub/controllers/slice_controller_unit_test.go
+++ b/pkg/hub/controllers/slice_controller_unit_test.go
@@ -165,7 +165,7 @@ func TestReconcileToUpdateWorkerSlice(t *testing.T) {
 	}{
 		context.WithValue(context.Background(), types.NamespacedName{Namespace: "kube-slice", Name: "kube-slice"}, controllerSlice),
 		reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-slice", Namespace: "kubeslice-system"}},
-		reconcile.Result{},
+		reconcile.Result{RequeueAfter: ReconcileInterval},
 		nil,
 	}
 	client := NewClient()

--- a/pkg/hub/controllers/slice_controller_unit_test.go
+++ b/pkg/hub/controllers/slice_controller_unit_test.go
@@ -21,7 +21,6 @@ package controllers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -155,8 +154,6 @@ func TestReconcileToReturnErrorWhileFetchingWorkerSlice(t *testing.T) {
 }
 
 func TestReconcileToUpdateWorkerSlice(t *testing.T) {
-	//TODO: Add a UT for when original-slice-name is missing
-	// controllerSlice.ObjectMeta.Labels["original-slice-name"] = "test-slice"
 	expected := struct {
 		ctx    context.Context
 		req    reconcile.Request
@@ -210,7 +207,6 @@ func TestReconcileToUpdateWorkerSlice(t *testing.T) {
 		Log:        ctrl.Log.WithName("controller").WithName("controllers").WithName("SliceConfig"),
 	}
 	result, err := reconciler.Reconcile(expected.ctx, expected.req)
-	fmt.Println(controllerSlice)
 	if expected.res != result {
 		t.Error("Expected response :", expected.res, " but got ", result)
 	}

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -266,7 +266,8 @@ var _ = Describe("Hub SliceController", func() {
 					Name:      "test-slice-4",
 					Namespace: PROJECT_NS,
 					Labels: map[string]string{
-						"worker-cluster": CLUSTER_NAME,
+						"worker-cluster":      CLUSTER_NAME,
+						"original-slice-name": "test-slice-4",
 					},
 				},
 				Spec: workerv1alpha1.WorkerSliceConfigSpec{
@@ -325,7 +326,7 @@ var _ = Describe("Hub SliceController", func() {
 			}, time.Second*10, time.Second*1).Should(BeTrue())
 			cs := hubSlice.Status.SliceHealth.ComponentStatuses
 
-			Expect(cs).Should(HaveLen(3))
+			Expect(cs).Should(HaveLen(2))
 
 			Expect(string(hubSlice.Status.SliceHealth.SliceHealthStatus)).Should(Equal("Warning"))
 
@@ -423,7 +424,7 @@ var _ = Describe("Hub SliceController", func() {
 			}
 
 			// wait for next reconcile loop
-			time.Sleep(10 * time.Second)
+			time.Sleep(120 * time.Second)
 
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: hubSlice.Name, Namespace: hubSlice.Namespace}, hubSlice)

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -356,6 +356,7 @@ var _ = Describe("Hub SliceController", func() {
 						Name: "slicegateway",
 						Labels: map[string]string{
 							"kubeslice.io/pod-type": "slicegateway",
+							"kubeslice.io/slice":    "test-slice-4",
 						},
 						Namespace: "kubeslice-system",
 					},
@@ -371,6 +372,7 @@ var _ = Describe("Hub SliceController", func() {
 						Name: "slicerouter",
 						Labels: map[string]string{
 							"kubeslice.io/pod-type": "router",
+							"kubeslice.io/slice":    "test-slice-4",
 						},
 						Namespace: "kubeslice-system",
 					},
@@ -385,7 +387,8 @@ var _ = Describe("Hub SliceController", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "egress",
 						Labels: map[string]string{
-							"istio": "egressgateway",
+							"istio":              "egressgateway",
+							"kubeslice.io/slice": "test-slice-4",
 						},
 						Namespace: "kubeslice-system",
 					},
@@ -400,7 +403,8 @@ var _ = Describe("Hub SliceController", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "ingress",
 						Labels: map[string]string{
-							"istio": "ingressgateway",
+							"istio":              "ingressgateway",
+							"kubeslice.io/slice": "test-slice-4",
 						},
 						Namespace: "kubeslice-system",
 					},

--- a/tests/spoke/node_restart_test.go
+++ b/tests/spoke/node_restart_test.go
@@ -20,9 +20,10 @@ package spoke_test
 
 import (
 	"context"
-	nsmv1 "github.com/networkservicemesh/sdk-k8s/pkg/tools/k8s/apis/networkservicemesh.io/v1"
 	"os"
 	"time"
+
+	nsmv1 "github.com/networkservicemesh/sdk-k8s/pkg/tools/k8s/apis/networkservicemesh.io/v1"
 
 	hubv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
@@ -187,8 +188,10 @@ Prefixes:
 
 			// set nodeip as ip of node1
 			cluster.Spec.NodeIPs = []string{node1.Status.Addresses[0].Address}
-			Expect(k8sClient.Update(ctx, cluster)).Should(Succeed())
-
+			Eventually(func() bool {
+				err := k8sClient.Update(ctx, cluster)
+				return err == nil
+			}, 10*time.Second, time.Millisecond*250).Should(BeTrue())
 			// start the reconcilers
 			Expect(k8sClient.Create(ctx, slice)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, vl3ServiceEndpoint)).Should(Succeed())

--- a/tests/spoke/slicegw_controller_test.go
+++ b/tests/spoke/slicegw_controller_test.go
@@ -226,13 +226,13 @@ var _ = Describe("Worker SlicegwController", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, sliceKey, createdSlice)
 				return err == nil
-			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*250, time.Millisecond*250).Should(BeTrue())
 
 			slicegwkey := types.NamespacedName{Name: "test-slicegw", Namespace: CONTROL_PLANE_NS}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, slicegwkey, createdSliceGw)
 				return err == nil
-			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*250, time.Millisecond*250).Should(BeTrue())
 
 			createdSliceGw.Status.Config.SliceGatewayHostType = "Server"
 			Eventually(func() bool {
@@ -329,13 +329,13 @@ var _ = Describe("Worker SlicegwController", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, sliceKey, createdSlice)
 				return err == nil
-			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*250, time.Millisecond*250).Should(BeTrue())
 
 			slicegwkey := types.NamespacedName{Name: "test-slicegw", Namespace: CONTROL_PLANE_NS}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, slicegwkey, createdSliceGw)
 				return err == nil
-			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*250, time.Millisecond*250).Should(BeTrue())
 
 			createdSliceGw.Status.Config.SliceGatewayHostType = "Client"
 			createdSliceGw.Status.Config.SliceGatewayRemoteGatewayID = "remote-gateway-id"
@@ -377,6 +377,12 @@ var _ = Describe("Worker SlicegwController", func() {
 			Expect(k8sClient.Create(ctx, sliceGw)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, appPod)).Should(Succeed())
 
+			sliceKey := types.NamespacedName{Name: "test-slice-4", Namespace: CONTROL_PLANE_NS}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, sliceKey, createdSlice)
+				return err == nil
+			}, time.Second*250, time.Millisecond*250).Should(BeTrue())
+
 			slicegwkey := types.NamespacedName{Name: "test-slicegw", Namespace: CONTROL_PLANE_NS}
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				err := k8sClient.Get(ctx, slicegwkey, createdSliceGw)
@@ -414,6 +420,12 @@ var _ = Describe("Worker SlicegwController", func() {
 			Expect(k8sClient.Create(ctx, vl3ServiceEndpoint)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, sliceGw)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, appPod)).Should(Succeed())
+
+			sliceKey := types.NamespacedName{Name: "test-slice-4", Namespace: CONTROL_PLANE_NS}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, sliceKey, createdSlice)
+				return err == nil
+			}, time.Second*250, time.Millisecond*250).Should(BeTrue())
 
 			slicegwkey := types.NamespacedName{Name: "test-slicegw", Namespace: CONTROL_PLANE_NS}
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {

--- a/tests/spoke/slicegw_controller_test.go
+++ b/tests/spoke/slicegw_controller_test.go
@@ -226,13 +226,13 @@ var _ = Describe("Worker SlicegwController", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, sliceKey, createdSlice)
 				return err == nil
-			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
 
 			slicegwkey := types.NamespacedName{Name: "test-slicegw", Namespace: CONTROL_PLANE_NS}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, slicegwkey, createdSliceGw)
 				return err == nil
-			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
 
 			createdSliceGw.Status.Config.SliceGatewayHostType = "Server"
 			Eventually(func() bool {
@@ -329,13 +329,13 @@ var _ = Describe("Worker SlicegwController", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, sliceKey, createdSlice)
 				return err == nil
-			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
 
 			slicegwkey := types.NamespacedName{Name: "test-slicegw", Namespace: CONTROL_PLANE_NS}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, slicegwkey, createdSliceGw)
 				return err == nil
-			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
+			}, time.Second*120, time.Millisecond*250).Should(BeTrue())
 
 			createdSliceGw.Status.Config.SliceGatewayHostType = "Client"
 			createdSliceGw.Status.Config.SliceGatewayRemoteGatewayID = "remote-gateway-id"


### PR DESCRIPTION
When multiple slices are deployed,
failure of one slice's components is reflected
in all the other sliceHealthStatus

Fix: added sliceName label to filter out
individual slice specific components