### PR TITLE
fix(): fixed slicegw health status for single cluster

### DIFF
--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -437,6 +437,11 @@ func (r *SliceReconciler) fetchSliceGatewayHealth(ctx context.Context, c *compon
 				cs.ComponentHealthStatus = spokev1alpha1.ComponentHealthStatusError
 				return cs, nil
 			}
+			if len(pods) != len(sliceGwDeployments.Items) {
+				log.Error(fmt.Errorf("number of pods do not match slicegw deployments running"), "unhealthy", "pod", c.name)
+				cs.ComponentHealthStatus = spokev1alpha1.ComponentHealthStatusError
+				return cs, nil
+			}
 			for _, pod := range pods {
 				if pod.Status.Phase != corev1.PodRunning {
 					log.Info("pod is not healthy", "component", c.name)

--- a/pkg/hub/controllers/slice_controller_unit_test.go
+++ b/pkg/hub/controllers/slice_controller_unit_test.go
@@ -27,6 +27,7 @@ import (
 	workerv1alpha1 "github.com/kubeslice/apis/pkg/worker/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -280,6 +281,11 @@ func TestUpdateSliceHealth(t *testing.T) {
 	client.StatusMock.On("Update",
 		mock.IsType(ctx),
 		mock.IsType(&workerv1alpha1.WorkerSliceConfig{}),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(expected.ctx),
+		mock.IsType(&appsv1.DeploymentList{}),
+		mock.IsType([]k8sclient.ListOption{}),
 	).Return(nil)
 	controllerSlice.Status.SliceHealth = &workerv1alpha1.SliceHealth{}
 	err := reconciler.updateSliceHealth(expected.ctx, controllerSlice)


### PR DESCRIPTION
For a single cluster, sliceGW pods are missing.
We need to handle component health status for two cases 1. single cluster 2. multiple cluster

case 1: we check if sliceGW deployment is present, expected no slicegw deployments hence, mark healthystate

case 2: we check if sliceGW deployment is present, expected 1 slicegw deployment, hence, list all pods and check if all are in Running state else mark as unhealthyState
