### PR TITLE
fix(): nodeip update while empty string

### DIFF
--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -166,7 +166,7 @@ func (r *Reconciler) updateClusterInfo(ctx context.Context, cr *hubv1alpha1.Clus
 
 	// Populate NodeIPs if not already updated
 	// Only needed to do the initial update. Later updates will be done by node reconciler
-	if isEmptyString(cr.Spec.NodeIPs) || cr.Spec.NodeIPs == nil || len(cr.Spec.NodeIPs) == 0 {
+	if isValidNodeIpList(cr.Spec.NodeIPs) || cr.Spec.NodeIPs == nil || len(cr.Spec.NodeIPs) == 0 {
 		nodeIPs, err := cluster.GetNodeIP(r.MeshClient)
 		if err != nil {
 			log.Error(err, "Error Getting nodeIP")
@@ -270,7 +270,7 @@ func (r *Reconciler) getCluster(ctx context.Context, req reconcile.Request) (*hu
 	return hubCluster, nil
 }
 
-func isEmptyString(nodeIPs []string) bool {
+func isValidNodeIpList(nodeIPs []string) bool {
 	for _, nodeIP := range nodeIPs {
 		if nodeIP == "" {
 			return true

--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -46,12 +46,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	log.Info("got cluster CR from hub", "cluster", cr)
 
-	// Post NodeIP and GeoLocation info only on first run or if the reconciler wasn't run for a while
-	if cr.Status.ClusterHealth == nil || time.Since(cr.Status.ClusterHealth.LastUpdated.Time) > 3*time.Minute {
-		log.Info("updating cluster info on controller")
-		if err := r.updateClusterInfo(ctx, cr); err != nil {
-			log.Error(err, "unable to update cluster info")
-		}
+	// Post NodeIP and GeoLocation info
+	log.Info("updating cluster info on controller")
+	if err := r.updateClusterInfo(ctx, cr); err != nil {
+		log.Error(err, "unable to update cluster info")
 	}
 
 	// Update dashboard creds if it hasn't already
@@ -168,7 +166,7 @@ func (r *Reconciler) updateClusterInfo(ctx context.Context, cr *hubv1alpha1.Clus
 
 	// Populate NodeIPs if not already updated
 	// Only needed to do the initial update. Later updates will be done by node reconciler
-	if cr.Spec.NodeIPs == nil || len(cr.Spec.NodeIPs) == 0 {
+	if isEmptyString(cr.Spec.NodeIPs) || cr.Spec.NodeIPs == nil || len(cr.Spec.NodeIPs) == 0 {
 		nodeIPs, err := cluster.GetNodeIP(r.MeshClient)
 		if err != nil {
 			log.Error(err, "Error Getting nodeIP")
@@ -270,6 +268,15 @@ func (r *Reconciler) getCluster(ctx context.Context, req reconcile.Request) (*hu
 		return nil, err
 	}
 	return hubCluster, nil
+}
+
+func isEmptyString(nodeIPs []string) bool {
+	for _, nodeIP := range nodeIPs {
+		if nodeIP == "" {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Reconciler) InjectClient(c client.Client) error {


### PR DESCRIPTION
### This PR contains following fixes:
* If cluster.spec.nodeIPs contains empty string []string{""} then worker operator is not able to update the nodeIPs.
* removed the check where we are checking if the `ClusterHealth == nil` this condition will be always true after the first reconcilation due to which in case there is a nodeIP change detected reconciler will never call the `updateClusterInfo` function.