### PR TITLE
fix(): slicegw health status for single cluster

### DIFF
--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -276,7 +276,7 @@ func (r *Reconciler) updateNodeIps(ctx context.Context, cr *hubv1alpha1.Cluster)
 		// the current nodeIpList (nodeIpList contains list of externalIPs or internalIPs)
 		// if the nodeIP is no longer available, we update the cluster CR on controller cluster
 		if cr.Status.NodeIPs == nil || len(cr.Status.NodeIPs) == 0 ||
-			!validatenodeips(nodeIPs, cr.Status.NodeIPs) || !isValidNodeIpList(nodeIPs) {
+			!validatenodeips(nodeIPs, cr.Status.NodeIPs) {
 			log.Info("Mismatch in node IP", "IP in use", cr.Status.NodeIPs, "IP to be used", nodeIPs)
 			cr.Status.NodeIPs = nodeIPs
 			toUpdate = true
@@ -395,15 +395,6 @@ func (r *Reconciler) getCluster(ctx context.Context, req reconcile.Request) (*hu
 		return nil, err
 	}
 	return hubCluster, nil
-}
-
-func isValidNodeIpList(nodeIPs []string) bool {
-	for _, nodeIP := range nodeIPs {
-		if nodeIP == "" {
-			return false
-		}
-	}
-	return true
 }
 
 func (r *Reconciler) InjectClient(c client.Client) error {

--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -276,7 +276,7 @@ func (r *Reconciler) updateNodeIps(ctx context.Context, cr *hubv1alpha1.Cluster)
 		// the current nodeIpList (nodeIpList contains list of externalIPs or internalIPs)
 		// if the nodeIP is no longer available, we update the cluster CR on controller cluster
 		if cr.Status.NodeIPs == nil || len(cr.Status.NodeIPs) == 0 ||
-			!validatenodeips(nodeIPs, cr.Status.NodeIPs) {
+			!validatenodeips(nodeIPs, cr.Status.NodeIPs) || !isValidNodeIpList(nodeIPs) {
 			log.Info("Mismatch in node IP", "IP in use", cr.Status.NodeIPs, "IP to be used", nodeIPs)
 			cr.Status.NodeIPs = nodeIPs
 			toUpdate = true
@@ -395,6 +395,15 @@ func (r *Reconciler) getCluster(ctx context.Context, req reconcile.Request) (*hu
 		return nil, err
 	}
 	return hubCluster, nil
+}
+
+func isValidNodeIpList(nodeIPs []string) bool {
+	for _, nodeIP := range nodeIPs {
+		if nodeIP == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *Reconciler) InjectClient(c client.Client) error {

--- a/pkg/hub/controllers/slice_controller_unit_test.go
+++ b/pkg/hub/controllers/slice_controller_unit_test.go
@@ -27,6 +27,7 @@ import (
 	workerv1alpha1 "github.com/kubeslice/apis/pkg/worker/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -280,6 +281,11 @@ func TestUpdateSliceHealth(t *testing.T) {
 	client.StatusMock.On("Update",
 		mock.IsType(ctx),
 		mock.IsType(&workerv1alpha1.WorkerSliceConfig{}),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(expected.ctx),
+		mock.IsType(&appsv1.DeploymentList{}),
+		mock.IsType([]k8sclient.ListOption{}),
 	).Return(nil)
 	controllerSlice.Status.SliceHealth = &workerv1alpha1.SliceHealth{}
 	err := reconciler.updateSliceHealth(expected.ctx, controllerSlice)


### PR DESCRIPTION
For a single cluster, sliceGW pods are missing.
We need to handle component health status for two cases 1. single cluster 2. multiple cluster

case 1: we check if sliceGW deployment is present, expected no slicegw deployments hence, mark healthystate

case 2: we check if sliceGW deployment is present, expected 1 slicegw deployment, hence, list all pods and check if all are in Running state else mark as unhealthyState