### PR TITLE
Slicegateway tunnel metrics

### DIFF
--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -66,7 +66,11 @@ type SliceGwReconciler struct {
 	NodeIPs               []string
 	NumberOfGateways      int
 
-	gaugeTunnelUp *prometheus.GaugeVec
+	gaugeTunnelUp         *prometheus.GaugeVec
+	gaugeTunnelLatency    *prometheus.GaugeVec
+	gaugeTunnelTxRate     *prometheus.GaugeVec
+	gaugeTunnelRxRate     *prometheus.GaugeVec
+	gaugeTunnelPacketLoss *prometheus.GaugeVec
 }
 
 // gwMap holds the mapping between gwPodName and NodePort number
@@ -674,9 +678,11 @@ func (r *SliceGwReconciler) findObjectsForNsmUpdate() (*kubeslicev1beta1.SliceGa
 // Setup SliceGwReconciler
 // Initializes metrics and sets up with manager
 func (r *SliceGwReconciler) Setup(mgr ctrl.Manager, mf metrics.MetricsFactory) error {
-	gaugeTunnelUp := mf.NewGauge("slicegateway_tunnel_up", "SliceGateway Tunnel up", []string{"slice", "slice_gateway"})
-
-	r.gaugeTunnelUp = gaugeTunnelUp
+	r.gaugeTunnelUp = mf.NewGauge("slicegateway_tunnel_up", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelLatency = mf.NewGauge("slicegateway_tunnel_latency", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelTxRate = mf.NewGauge("slicegateway_tunnel_txrate", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelRxRate = mf.NewGauge("slicegateway_tunnel_rxrate", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelPacketLoss = mf.NewGauge("slicegateway_tunnel_packetloss", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
 
 	return r.SetupWithManager(mgr)
 }

--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -679,10 +679,10 @@ func (r *SliceGwReconciler) findObjectsForNsmUpdate() (*kubeslicev1beta1.SliceGa
 // Initializes metrics and sets up with manager
 func (r *SliceGwReconciler) Setup(mgr ctrl.Manager, mf metrics.MetricsFactory) error {
 	r.gaugeTunnelUp = mf.NewGauge("slicegateway_tunnel_up", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
-	r.gaugeTunnelLatency = mf.NewGauge("slicegateway_tunnel_latency", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
-	r.gaugeTunnelTxRate = mf.NewGauge("slicegateway_tunnel_txrate", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
-	r.gaugeTunnelRxRate = mf.NewGauge("slicegateway_tunnel_rxrate", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
-	r.gaugeTunnelPacketLoss = mf.NewGauge("slicegateway_tunnel_packetloss", "SliceGateway Tunnel up", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelLatency = mf.NewGauge("slicegateway_tunnel_latency", "SliceGateway Tunnel Latency", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelTxRate = mf.NewGauge("slicegateway_tunnel_txrate", "SliceGateway Tunnel TxRate", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelRxRate = mf.NewGauge("slicegateway_tunnel_rxrate", "SliceGateway Tunnel RxRate", []string{"slice", "slice_gateway", "slice_gateway_pod"})
+	r.gaugeTunnelPacketLoss = mf.NewGauge("slicegateway_tunnel_packetloss", "SliceGateway Tunnel Packet Loss rate", []string{"slice", "slice_gateway", "slice_gateway_pod"})
 
 	return r.SetupWithManager(mgr)
 }

--- a/controllers/slicegateway/slicegateway.go
+++ b/controllers/slicegateway/slicegateway.go
@@ -684,10 +684,15 @@ func (r *SliceGwReconciler) ReconcileGwPodStatus(ctx context.Context, slicegatew
 		// Update tunnel metrics
 		for _, pod := range slicegateway.Status.GatewayPodStatus {
 			s := 1.0
-			if pod.TunnelStatus.Status == int32(gwsidecarpb.TunnelStatusType_GW_TUNNEL_STATE_DOWN) {
+			ts := pod.TunnelStatus
+			if ts.Status == int32(gwsidecarpb.TunnelStatusType_GW_TUNNEL_STATE_DOWN) {
 				s = 0.0
 			}
 			r.gaugeTunnelUp.WithLabelValues(slicegateway.Spec.SliceName, slicegateway.Name, pod.PodName).Set(s)
+			r.gaugeTunnelLatency.WithLabelValues(slicegateway.Spec.SliceName, slicegateway.Name, pod.PodName).Set(float64(ts.Latency))
+			r.gaugeTunnelTxRate.WithLabelValues(slicegateway.Spec.SliceName, slicegateway.Name, pod.PodName).Set(float64(ts.TxRate))
+			r.gaugeTunnelRxRate.WithLabelValues(slicegateway.Spec.SliceName, slicegateway.Name, pod.PodName).Set(float64(ts.RxRate))
+			r.gaugeTunnelPacketLoss.WithLabelValues(slicegateway.Spec.SliceName, slicegateway.Name, pod.PodName).Set(float64(ts.PacketLoss))
 		}
 
 		err := r.Status().Update(ctx, slicegateway)

--- a/controllers/slicegateway/slicegateway.go
+++ b/controllers/slicegateway/slicegateway.go
@@ -680,6 +680,16 @@ func (r *SliceGwReconciler) ReconcileGwPodStatus(ctx context.Context, slicegatew
 		log.Info("gwPodsInfo", "gwPodsInfo", gwPodsInfo)
 		slicegateway.Status.GatewayPodStatus = gwPodsInfo
 		slicegateway.Status.ConnectionContextUpdatedOn = 0
+
+		// Update tunnel metrics
+		for _, pod := range slicegateway.Status.GatewayPodStatus {
+			s := 1.0
+			if pod.TunnelStatus.Status == int32(gwsidecarpb.TunnelStatusType_GW_TUNNEL_STATE_DOWN) {
+				s = 0.0
+			}
+			r.gaugeTunnelUp.WithLabelValues(slicegateway.Spec.SliceName, slicegateway.Name, pod.PodName).Set(s)
+		}
+
 		err := r.Status().Update(ctx, slicegateway)
 		if err != nil {
 			debugLog.Error(err, "error while update", "Failed to update SliceGateway status for gateway status")

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/kubeslice/kubeslice-monitoring/pkg/metrics"
 	"github.com/kubeslice/worker-operator/controllers"
@@ -163,10 +164,9 @@ func main() {
 	})
 
 	mf, err := metrics.NewMetricsFactory(ctrlmetrics.Registry, metrics.MetricsFactoryOptions{
+		Project:             strings.TrimPrefix(hub.ProjectNamespace, "kubeslice_"),
 		Cluster:             controllers.ClusterName,
-		Project:             hub.ProjectNamespace,
 		ReportingController: "worker-operator",
-		Namespace:           controllers.ControlPlaneNamespace,
 	})
 	if err != nil {
 		setupLog.With("error", err).Error("unable to initializ metrics factory")
@@ -203,7 +203,7 @@ func main() {
 		WorkerNetOpClient:     workerNetOPClient,
 		EventRecorder:         sliceGwEventRecorder,
 		NumberOfGateways:      2,
-	}).SetupWithManager(mgr); err != nil {
+	}).Setup(mgr, mf); err != nil {
 		setupLog.With("error", err).Error("unable to create controller", "controller", "SliceGw")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 	})
 
 	mf, err := metrics.NewMetricsFactory(ctrlmetrics.Registry, metrics.MetricsFactoryOptions{
-		Project:             strings.TrimPrefix(hub.ProjectNamespace, "kubeslice_"),
+		Project:             strings.TrimPrefix(hub.ProjectNamespace, "kubeslice-"),
 		Cluster:             controllers.ClusterName,
 		ReportingController: "worker-operator",
 	})

--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -46,7 +46,7 @@ type Reconciler struct {
 
 func NewReconciler(mc client.Client, er events.EventRecorder, mf metrics.MetricsFactory) *Reconciler {
 	gaugeClusterUp := mf.NewGauge("cluster_up", "Kubeslice cluster health status", []string{})
-	gaugeComponentUp := mf.NewGauge("cluster_component_up", "Kubeslice cluster component health status", []string{"component"})
+	gaugeComponentUp := mf.NewGauge("cluster_component_up", "Kubeslice cluster component health status", []string{"slice_cluster_component"})
 
 	return &Reconciler{
 		MeshClient:    mc,

--- a/pkg/hub/manager/manager.go
+++ b/pkg/hub/manager/manager.go
@@ -88,7 +88,7 @@ func Start(meshClient client.Client, ctx context.Context) {
 	mf, _ := metrics.NewMetricsFactory(
 		ctrlmetrics.Registry,
 		metrics.MetricsFactoryOptions{
-			Project:             strings.TrimPrefix(ProjectNamespace, "kubeslice_"),
+			Project:             strings.TrimPrefix(ProjectNamespace, "kubeslice-"),
 			Cluster:             ClusterName,
 			ReportingController: "worker-operator",
 		},

--- a/pkg/hub/manager/manager.go
+++ b/pkg/hub/manager/manager.go
@@ -21,6 +21,7 @@ package manager
 import (
 	"context"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -87,10 +88,9 @@ func Start(meshClient client.Client, ctx context.Context) {
 	mf, _ := metrics.NewMetricsFactory(
 		ctrlmetrics.Registry,
 		metrics.MetricsFactoryOptions{
-			Project:             ProjectNamespace,
+			Project:             strings.TrimPrefix(ProjectNamespace, "kubeslice_"),
 			Cluster:             ClusterName,
 			ReportingController: "worker-operator",
-			Namespace:           controllers.ControlPlaneNamespace,
 		},
 	)
 

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -181,7 +181,7 @@ var _ = BeforeSuite(func() {
 		WorkerRouterClient:    workerClientRouterEmulator,
 		WorkerNetOpClient:     workerClientNetopEmulator,
 		NumberOfGateways:      2,
-	}).SetupWithManager(k8sManager)
+	}).Setup(k8sManager, mf)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&serviceimport.Reconciler{


### PR DESCRIPTION
Added metrics for slicegateway tunnel status

![2023-04-22 13:02:42+02:00](https://user-images.githubusercontent.com/6793260/233780357-07505872-c725-42cc-ad1e-e4df92e40b12.png)

Also fixed label names in existing metrics