### PR TITLE
Metrics for serviceimport endpoints

### DIFF
--- a/controllers/serviceexport/reconciler.go
+++ b/controllers/serviceexport/reconciler.go
@@ -212,7 +212,7 @@ func (r Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resul
 // Setup ServiceExport Reconciler
 // Initializes metrics and sets up with manager
 func (r *Reconciler) Setup(mgr ctrl.Manager, mf metrics.MetricsFactory) error {
-	gaugeEndpoints := mf.NewGauge("serviceexport_endpoints", "Active endpoints in serviceexport", []string{"slice", "namespace", "service"})
+	gaugeEndpoints := mf.NewGauge("serviceexport_endpoints", "Active endpoints in serviceexport", []string{"slice", "slice_namespace", "slice_service"})
 
 	r.gaugeEndpoints = gaugeEndpoints
 

--- a/controllers/serviceimport/reconciler.go
+++ b/controllers/serviceimport/reconciler.go
@@ -84,14 +84,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return result, err
 	}
 
-	r.gaugeEndpoints.WithLabelValues(serviceimport.Spec.Slice, serviceimport.Namespace, serviceimport.Name).Set(float64(serviceimport.Status.AvailableEndpoints))
-
 	if serviceimport.Status.ExposedPorts != portListToDisplayString(serviceimport.Spec.Ports) {
 		return r.updateServiceImportPorts(ctx, serviceimport)
 	}
 
 	if serviceimport.Status.AvailableEndpoints != len(serviceimport.Status.Endpoints) {
 		serviceimport.Status.AvailableEndpoints = len(serviceimport.Status.Endpoints)
+		r.gaugeEndpoints.WithLabelValues(serviceimport.Spec.Slice, serviceimport.Namespace, serviceimport.Name).Set(float64(serviceimport.Status.AvailableEndpoints))
 		err = r.Status().Update(ctx, serviceimport)
 		if err != nil {
 			log.Error(err, "Failed to update availableendpoints")

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"github.com/kubeslice/kubeslice-monitoring/pkg/metrics"
 	"github.com/kubeslice/worker-operator/controllers"
@@ -164,9 +165,8 @@ func main() {
 
 	mf, err := metrics.NewMetricsFactory(ctrlmetrics.Registry, metrics.MetricsFactoryOptions{
 		Cluster:             controllers.ClusterName,
-		Project:             hub.ProjectNamespace,
+		Project:             strings.TrimPrefix(hub.ProjectNamespace, "kubeslice_"),
 		ReportingController: "worker-operator",
-		Namespace:           controllers.ControlPlaneNamespace,
 	})
 	if err != nil {
 		setupLog.With("error", err).Error("unable to initializ metrics factory")

--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -46,7 +46,7 @@ type Reconciler struct {
 
 func NewReconciler(mc client.Client, er events.EventRecorder, mf metrics.MetricsFactory) *Reconciler {
 	gaugeClusterUp := mf.NewGauge("cluster_up", "Kubeslice cluster health status", []string{})
-	gaugeComponentUp := mf.NewGauge("cluster_component_up", "Kubeslice cluster component health status", []string{"component"})
+	gaugeComponentUp := mf.NewGauge("cluster_component_up", "Kubeslice cluster component health status", []string{"slice_cluster_component"})
 
 	return &Reconciler{
 		MeshClient:    mc,

--- a/pkg/hub/manager/manager.go
+++ b/pkg/hub/manager/manager.go
@@ -21,6 +21,7 @@ package manager
 import (
 	"context"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -87,10 +88,9 @@ func Start(meshClient client.Client, ctx context.Context) {
 	mf, _ := metrics.NewMetricsFactory(
 		ctrlmetrics.Registry,
 		metrics.MetricsFactoryOptions{
-			Project:             ProjectNamespace,
+			Project:             strings.TrimPrefix(ProjectNamespace, "kubeslice_"),
 			Cluster:             ClusterName,
 			ReportingController: "worker-operator",
-			Namespace:           controllers.ControlPlaneNamespace,
 		},
 	)
 

--- a/tests/hub/hub_suite_test.go
+++ b/tests/hub/hub_suite_test.go
@@ -138,7 +138,6 @@ var _ = BeforeSuite(func() {
 			Project:             PROJECT_NS,
 			Cluster:             CLUSTER_NAME,
 			ReportingController: "worker-operator",
-			Namespace:           controllers.ControlPlaneNamespace,
 		},
 	)
 

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -198,9 +198,6 @@ var _ = Describe("Hub SliceController", func() {
 				return errors.IsNotFound(err)
 			}, time.Second*10, time.Millisecond*250).Should(BeTrue())
 
-			m := utils.GetCounterMetricFromRegistry(MetricRegistry, "kubeslice_slice_deleted_total")
-			Expect(m).To(ContainElement(1.0))
-
 		})
 	})
 

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -45,8 +45,6 @@ var _ = Describe("Hub SliceController", func() {
 		var ipamOctet = 1
 
 		BeforeEach(func() {
-			utils.ResetMetricRegistry(MetricRegistry)
-
 			// Prepare k8s objects
 			hubSlice = &workerv1alpha1.WorkerSliceConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -97,11 +95,17 @@ var _ = Describe("Hub SliceController", func() {
 			Expect(createdSlice.Status.SliceConfig.SliceIpam.IpamClusterOctet).To(Equal(1))
 			Expect(createdSlice.Status.SliceConfig.ClusterSubnetCIDR).To(Equal("10.0.16.0/20"))
 
-			m := utils.GetCounterMetricFromRegistry(MetricRegistry, "kubeslice_slice_created_total")
-			Expect(m).To(ContainElement(1.0))
+			m, err := utils.GetCounterMetricFromRegistry(MetricRegistry, "kubeslice_slice_created_total", map[string]string{
+				"slice": "test-slice-1",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).To(Equal(1.0))
 
-			m = utils.GetCounterMetricFromRegistry(MetricRegistry, "kubeslice_slice_updated_total")
-			Expect(m).To(ContainElement(2.0))
+			m, err = utils.GetCounterMetricFromRegistry(MetricRegistry, "kubeslice_slice_updated_total", map[string]string{
+				"slice": "test-slice-1",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).To(Equal(2.0))
 		})
 
 		It("Should Generate Events", func() {
@@ -156,7 +160,6 @@ var _ = Describe("Hub SliceController", func() {
 		var createdSlice *kubeslicev1beta1.Slice
 
 		BeforeEach(func() {
-			utils.ResetMetricRegistry(MetricRegistry)
 
 			hundred := 100
 			// Prepare k8s objects

--- a/tests/spoke/service_import_test.go
+++ b/tests/spoke/service_import_test.go
@@ -42,7 +42,6 @@ var _ = Describe("ServiceImportController", func() {
 		var svcim *kubeslicev1beta1.ServiceImport
 		var createdSlice *kubeslicev1beta1.Slice
 		BeforeEach(func() {
-			utils.ResetMetricRegistry(MetricRegistry)
 
 			// Prepare k8s objects for slice and kubeslice-dns service
 			slice = &kubeslicev1beta1.Slice{
@@ -179,9 +178,12 @@ var _ = Describe("ServiceImportController", func() {
 				return true
 			}, time.Second*30, time.Millisecond*250).Should(BeTrue())
 
-			m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_serviceimport_endpoints")
-			Expect(m).To(ContainElement(1.0))
-
+			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_serviceimport_endpoints", map[string]string{
+				"slice":         "test-slice-2",
+				"slice_service": "iperf-server",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).To(Equal(1.0))
 		})
 	})
 })

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/kubeslice/kubeslice-monitoring/pkg/metrics"
 	nsmv1 "github.com/networkservicemesh/sdk-k8s/pkg/tools/k8s/apis/networkservicemesh.io/v1"
-	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -75,6 +75,8 @@ var workerClientNetopEmulator *workernetop.ClientEmulator
 
 const CONTROL_PLANE_NS = "kubeslice-system"
 const PROJECT_NS = "kubeslice-cisco"
+
+var MetricRegistry = prometheus.NewRegistry()
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
@@ -137,11 +139,10 @@ var _ = BeforeSuite(func() {
 	workerClientNetopEmulator, err = workernetop.NewClientEmulator()
 	Expect(err).ToNot(HaveOccurred())
 
-	mf, err := metrics.NewMetricsFactory(ctrlmetrics.Registry, metrics.MetricsFactoryOptions{
+	mf, err := metrics.NewMetricsFactory(MetricRegistry, metrics.MetricsFactoryOptions{
 		Cluster:             "cluster-test",
 		Project:             PROJECT_NS,
 		ReportingController: "worker-operator",
-		Namespace:           CONTROL_PLANE_NS,
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -191,7 +191,7 @@ var _ = BeforeSuite(func() {
 		EventRecorder: &events.EventRecorder{
 			Recorder: &record.FakeRecorder{},
 		},
-	}).SetupWithManager(k8sManager)
+	}).Setup(k8sManager, mf)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&namespace.Reconciler{

--- a/tests/utils/metrics.go
+++ b/tests/utils/metrics.go
@@ -1,38 +1,61 @@
 package utils
 
 import (
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
-func ResetMetricRegistry(r *prometheus.Registry) {
+func GetCounterMetricFromRegistry(r *prometheus.Registry, name string, labels map[string]string) (float64, error) {
 	mf, _ := r.Gather()
-	for _, m := range mf {
-		m.Reset()
-	}
-}
-
-func GetCounterMetricFromRegistry(r *prometheus.Registry, name string) []float64 {
-	mf, _ := r.Gather()
-	values := []float64{}
+	var av []*dto.Metric
 	for _, m := range mf {
 		if *m.Name == name {
 			for _, v := range m.Metric {
-				values = append(values, v.Counter.GetValue())
+				av = m.GetMetric()
+				if matchLabels(v.Label, labels) {
+					return v.Counter.GetValue(), nil
+				}
 			}
 		}
 	}
-	return values
+	return 0, fmt.Errorf("no matching metric; available metrics: %v", av)
 }
 
-func GetGaugeMetricFromRegistry(r *prometheus.Registry, name string) []float64 {
+func GetGaugeMetricFromRegistry(r *prometheus.Registry, name string, labels map[string]string) (float64, error) {
 	mf, _ := r.Gather()
-	values := []float64{}
+	var av []*dto.Metric
 	for _, m := range mf {
 		if *m.Name == name {
 			for _, v := range m.Metric {
-				values = append(values, v.Gauge.GetValue())
+				av = m.GetMetric()
+				if matchLabels(v.Label, labels) {
+					return v.Gauge.GetValue(), nil
+				}
 			}
 		}
 	}
-	return values
+	return 0, fmt.Errorf("no matching metric; available metrics: %v", av)
+}
+
+func matchLabels(lp []*dto.LabelPair, ml map[string]string) bool {
+
+	for k, v := range ml {
+		found := false
+
+		for _, l := range lp {
+			if k == *l.Name && v == l.GetValue() {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+
+	}
+
+	return true
 }


### PR DESCRIPTION
## Description

Adds a new metric `kubeslice_serviceimport_endpoints` in serviceimport reconciler with corresponding UTs. This is a guage which shows number of active endpoints for each serviceimport in a slice.

Also made some minor label changes to existing metrics


<!--

If this is a PR to the release branch, include the link to PR to master which includes cherry-picked changes from this PR

PR to Master: #

-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a helm chart update (eg: CRD changes)
- [x] E2e not required (eg: Updates in test cases)

## How Has This Been Tested?

- [x] Create a ServiceExport on a slice to expose bookinfo details pod. Verify that the serviceimport comes up with correct list of endpoints. Then port-forward the operator pod to view prometheus metrics exposed. From the metrics page, verify that the above metric is present with the correct value.

## Checklist:

- [x] Run `go fmt`
- [x] Added relevant UTs and ITs