### PR TITLE
Metrics for networkpolicy

### DIFF
--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func main() {
 		Log:           ctrl.Log.WithName("controllers").WithName("networkpolicy"),
 		Scheme:        mgr.GetScheme(),
 		EventRecorder: netpolEventRecorder,
-	}).SetupWithManager(mgr); err != nil {
+	}).Setup(mgr, mf); err != nil {
 		setupLog.With("error", err, "controller", "networkpolicy").Error("unable to create controller")
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 		Log:           ctrl.Log.WithName("controllers").WithName("ServiceImport"),
 		Scheme:        mgr.GetScheme(),
 		EventRecorder: serviceImportEventRecorder,
-	}).SetupWithManager(mgr); err != nil {
+	}).Setup(mgr, mf); err != nil {
 		setupLog.With("error", err, "controller", "ServiceImport").Error("unable to create controller")
 		os.Exit(1)
 	}

--- a/tests/spoke/spoke_suite_test.go
+++ b/tests/spoke/spoke_suite_test.go
@@ -213,7 +213,7 @@ var _ = BeforeSuite(func() {
 		Log:           ctrl.Log.WithName("controllers").WithName("networkpolicy"),
 		Scheme:        k8sManager.GetScheme(),
 		EventRecorder: netpolEventRecorder,
-	}).SetupWithManager(k8sManager)
+	}).Setup(k8sManager, mf)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&cluster.NodeReconciler{


### PR DESCRIPTION
## Description

Adds a new metric `kubeslice_netpol_violations_active` in netpol reconciler. This is a guage which shows number of active violations in netpol.
Also fixed a bug in main.go where serviceimport metric was not intiialized


<!--

If this is a PR to the release branch, include the link to PR to master which includes cherry-picked changes from this PR

PR to Master: #

-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a helm chart update (eg: CRD changes)
- [x] E2e not required (eg: Updates in test cases)

## How Has This Been Tested?

- [x] Create Slice with isolation enabled. Adjust the netpol manually to trigger the violation and verify the metrics.

## Checklist:

- [x] Run `go fmt`
- [x] Added relevant UTs and ITs