### PR TITLE
Add slice health metrics

### DIFF
--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -63,7 +63,7 @@ func NewSliceReconciler(mc client.Client, er *events.EventRecorder, mf metrics.M
 		counterSliceUpdationFailed: mf.NewCounter("slice_updation_failed_total", "Slice updation failed in worker", []string{"slice"}),
 		counterSliceDeletionFailed: mf.NewCounter("slice_deletion_failed_total", "Slice deletion failed in worker", []string{"slice"}),
 		gaugeSliceUp:               mf.NewGauge("slice_up", "Kubeslice slice health status", []string{}),
-		gaugeComponentUp:           mf.NewGauge("slice_component_up", "Kubeslice slice component health status", []string{"component"}),
+		gaugeComponentUp:           mf.NewGauge("slice_component_up", "Kubeslice slice component health status", []string{"slice_component"}),
 	}
 }
 

--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -62,8 +62,8 @@ func NewSliceReconciler(mc client.Client, er *events.EventRecorder, mf metrics.M
 		counterSliceCreationFailed: mf.NewCounter("slice_creation_failed_total", "Slice creation failed in worker", []string{"slice"}),
 		counterSliceUpdationFailed: mf.NewCounter("slice_updation_failed_total", "Slice updation failed in worker", []string{"slice"}),
 		counterSliceDeletionFailed: mf.NewCounter("slice_deletion_failed_total", "Slice deletion failed in worker", []string{"slice"}),
-		gaugeSliceUp:               mf.NewGauge("slice_up", "Kubeslice slice health status", []string{}),
-		gaugeComponentUp:           mf.NewGauge("slice_component_up", "Kubeslice slice component health status", []string{"slice_component"}),
+		gaugeSliceUp:               mf.NewGauge("slice_up", "Kubeslice slice health status", []string{"slice"}),
+		gaugeComponentUp:           mf.NewGauge("slice_component_up", "Kubeslice slice component health status", []string{"slice", "slice_component"}),
 	}
 }
 
@@ -501,16 +501,16 @@ func (r *SliceReconciler) fetchSliceGatewayHealth(ctx context.Context, c *compon
 
 func (r *SliceReconciler) UpdateSliceHealthMetrics(slice *spokev1alpha1.WorkerSliceConfig) {
 	if slice.Status.SliceHealth.SliceHealthStatus == spokev1alpha1.SliceHealthStatusNormal {
-		r.gaugeSliceUp.WithLabelValues().Set(1)
+		r.gaugeSliceUp.WithLabelValues(slice.Name).Set(1)
 	} else {
-		r.gaugeSliceUp.WithLabelValues().Set(0)
+		r.gaugeSliceUp.WithLabelValues(slice.Name).Set(0)
 	}
 
 	for _, cs := range slice.Status.SliceHealth.ComponentStatuses {
 		if cs.ComponentHealthStatus == spokev1alpha1.ComponentHealthStatusNormal {
-			r.gaugeComponentUp.WithLabelValues(cs.Component).Set(1)
+			r.gaugeComponentUp.WithLabelValues(slice.Name, cs.Component).Set(1)
 		} else {
-			r.gaugeComponentUp.WithLabelValues(cs.Component).Set(0)
+			r.gaugeComponentUp.WithLabelValues(slice.Name, cs.Component).Set(0)
 		}
 	}
 }

--- a/tests/hub/hub_suite_test.go
+++ b/tests/hub/hub_suite_test.go
@@ -147,6 +147,7 @@ var _ = BeforeSuite(func() {
 		testSliceEventRecorder,
 		mf,
 	)
+	sr.ReconcileInterval = 5 * time.Second
 
 	testSliceGwEventRecorder := events.NewEventRecorder(k8sManager.GetEventRecorderFor("test-slicegw-controller"))
 	sgwr := &controllers.SliceGwReconciler{

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -347,11 +347,15 @@ var _ = Describe("Hub SliceController", func() {
 
 			for _, c := range cs {
 				Expect(string(c.ComponentHealthStatus)).Should(Equal("Error"))
-				m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up")
-				Expect(m).To(ContainElement(0.0))
+				m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up", map[string]string{
+					"slice_component": c.Component,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).To(Equal(0.0))
 			}
-			m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up")
-			Expect(m).To(ContainElement(0.0))
+			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up", map[string]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).To(Equal(0.0))
 		})
 
 		It("Should update slice CR with component status as normal when pods running", func() {
@@ -499,11 +503,15 @@ var _ = Describe("Hub SliceController", func() {
 			for i, c := range cs {
 				Expect(c.Component).Should(Equal(pods[i].ObjectMeta.Name))
 				Expect(string(c.ComponentHealthStatus)).Should(Equal("Normal"))
-				m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up")
-				Expect(m).To(ContainElement(1.0))
+				m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up", map[string]string{
+					"slice_component": c.Component,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m).To(Equal(1.0))
 			}
-			m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up")
-			Expect(m).To(ContainElement(1.0))
+			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up", map[string]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).To(Equal(1.0))
 		})
 	})
 })

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -348,12 +348,15 @@ var _ = Describe("Hub SliceController", func() {
 			for _, c := range cs {
 				Expect(string(c.ComponentHealthStatus)).Should(Equal("Error"))
 				m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up", map[string]string{
+					"slice":           "test-slice-4",
 					"slice_component": c.Component,
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(m).To(Equal(0.0))
 			}
-			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up", map[string]string{})
+			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up", map[string]string{
+				"slice": "test-slice-4",
+			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).To(Equal(0.0))
 		})
@@ -504,12 +507,15 @@ var _ = Describe("Hub SliceController", func() {
 				Expect(c.Component).Should(Equal(pods[i].ObjectMeta.Name))
 				Expect(string(c.ComponentHealthStatus)).Should(Equal("Normal"))
 				m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up", map[string]string{
+					"slice":           "test-slice-4",
 					"slice_component": c.Component,
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(m).To(Equal(1.0))
 			}
-			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up", map[string]string{})
+			m, err := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up", map[string]string{
+				"slice": "test-slice-4",
+			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m).To(Equal(1.0))
 		})

--- a/tests/hub/slice_controller_test.go
+++ b/tests/hub/slice_controller_test.go
@@ -347,7 +347,11 @@ var _ = Describe("Hub SliceController", func() {
 
 			for _, c := range cs {
 				Expect(string(c.ComponentHealthStatus)).Should(Equal("Error"))
+				m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up")
+				Expect(m).To(ContainElement(0.0))
 			}
+			m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up")
+			Expect(m).To(ContainElement(0.0))
 		})
 
 		It("Should update slice CR with component status as normal when pods running", func() {
@@ -495,7 +499,11 @@ var _ = Describe("Hub SliceController", func() {
 			for i, c := range cs {
 				Expect(c.Component).Should(Equal(pods[i].ObjectMeta.Name))
 				Expect(string(c.ComponentHealthStatus)).Should(Equal("Normal"))
+				m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_component_up")
+				Expect(m).To(ContainElement(1.0))
 			}
+			m := utils.GetGaugeMetricFromRegistry(MetricRegistry, "kubeslice_slice_up")
+			Expect(m).To(ContainElement(1.0))
 		})
 	})
 })


### PR DESCRIPTION
This PR adds the slice health related metrics.

1. kubeslice_slice_up : gauge set to 1 when slice health is Normal state and set to 0 when slice health is in warning state
2. kubeslice_slice_component_up : gauge set to 1 when slice component is in Normal state and set to 0 when slice component is in Error state

Added integration tests to cover both the states of the above metrics