### PR TITLE
fix(): use correct slicename

### DIFF
--- a/pkg/hub/controllers/slice_controller_unit_test.go
+++ b/pkg/hub/controllers/slice_controller_unit_test.go
@@ -203,6 +203,11 @@ func TestReconcileToUpdateWorkerSlice(t *testing.T) {
 		mock.IsType(&corev1.PodList{}),
 		mock.IsType([]k8sclient.ListOption{}),
 	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&appsv1.DeploymentList{}),
+		mock.IsType([]k8sclient.ListOption{}),
+	).Return(nil)
 	client.StatusMock.On("Update",
 		mock.IsType(ctx),
 		mock.IsType(&workerv1alpha1.WorkerSliceConfig{}),


### PR DESCRIPTION
slice name of the workersliceConfig is currently used, this change uses the correct slice name from SliceConfig, which is part of the spec for WorkerSliceConfig