### PR TITLE
fix(): race condition issue fixed btw slice detach and cluster deregister

### DIFF
--- a/pkg/hub/controllers/cluster/deregister_unit_test.go
+++ b/pkg/hub/controllers/cluster/deregister_unit_test.go
@@ -9,6 +9,7 @@ import (
 
 	hubv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
 	"github.com/kubeslice/kubeslice-monitoring/pkg/metrics"
+	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	utilmock "github.com/kubeslice/worker-operator/pkg/mocks"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
@@ -121,6 +122,16 @@ func TestCreateDeregisterJobPositiveScenarios(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
@@ -252,6 +263,16 @@ func TestReconcilerFailToCreateServiceAccount(t *testing.T) {
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
 	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
 		mock.IsType(&corev1.ServiceAccount{}),
@@ -294,6 +315,16 @@ func TestReconcilerFailToFetchOperatorClusterRole(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
@@ -347,6 +378,16 @@ func TestReconcilerFailToCreateClusterRole(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
@@ -410,6 +451,16 @@ func TestReconcilerFailToCreateClusterRoleBinding(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
@@ -478,6 +529,16 @@ func TestReconcilerFailToCreateConfigmap(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
@@ -560,6 +621,16 @@ func TestReconcilerFailToDeleteJob(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),
@@ -653,6 +724,16 @@ func TestReconcilerFailToCreateDeregisterJob(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),

--- a/pkg/hub/controllers/cluster/reconciler_unit_test.go
+++ b/pkg/hub/controllers/cluster/reconciler_unit_test.go
@@ -9,6 +9,7 @@ import (
 	hubv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
 	mevents "github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"github.com/kubeslice/kubeslice-monitoring/pkg/metrics"
+	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/controllers"
 	ossEvents "github.com/kubeslice/worker-operator/events"
 	utilmock "github.com/kubeslice/worker-operator/pkg/mocks"
@@ -178,6 +179,16 @@ func TestReconcilerHandleExternalDependency(t *testing.T) {
 		mock.IsType(ctx),
 		mock.IsType(&hubv1alpha1.Cluster{}),
 		mock.IsType([]k8sclient.UpdateOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
+	).Return(nil)
+	client.On("List",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.SliceGatewayList{}),
+		mock.IsType([]k8sclient.ListOption(nil)),
 	).Return(nil)
 	client.On("Create",
 		mock.IsType(ctx),


### PR DESCRIPTION
The race condition issue that occurs when deleting slices and deregistering clusters quickly has been resolved