### PR TITLE
fix(): Changed istio serviceentry resolution to static

### DIFF
--- a/controllers/serviceimport/istio_serviceentry.go
+++ b/controllers/serviceimport/istio_serviceentry.go
@@ -190,6 +190,10 @@ func serviceEntryUpdateNeeded(se *istiov1beta1.ServiceEntry, endpoint kubeslicev
 		return true
 	}
 
+	if len(se.Spec.Endpoints) == 0 {
+                return true
+        }
+
 	if len(se.Spec.Endpoints) > 0 && se.Spec.Endpoints[0].Address != endpoint.IP {
 		return true
 	}

--- a/controllers/serviceimport/istio_serviceentry.go
+++ b/controllers/serviceimport/istio_serviceentry.go
@@ -191,8 +191,8 @@ func serviceEntryUpdateNeeded(se *istiov1beta1.ServiceEntry, endpoint kubeslicev
 	}
 
 	if len(se.Spec.Endpoints) == 0 {
-                return true
-        }
+		return true
+	}
 
 	if len(se.Spec.Endpoints) > 0 && se.Spec.Endpoints[0].Address != endpoint.IP {
 		return true


### PR DESCRIPTION
Changed the istio serviceentry resolution to static from dns when setting up the istio egress gw. There is a problem with dns resolution when the istio-proxy is run in the router mode wherein the resolution of hostnames fails intermittently and in some cases it remains in the failed state for a very long time. This issue is not seen with istio-proxy running in sidecar mode.

We use static resolution for istio ingress gw, following the same practice for egress gw as well.