### PR TITLE
fix(): Initialize labels field as an empty map

### DIFF
--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -171,8 +171,9 @@ func MutatePod(pod *corev1.Pod, sliceName string) *corev1.Pod {
 	}
 	pod.ObjectMeta.Annotations[AdmissionWebhookAnnotationStatusKey] = "injected"
 
-	if pod.ObjectMeta.Annotations == nil {
-		pod.ObjectMeta.Annotations = map[string]string{}
+	// Initialize the Labels field as an empty map
+	if pod.ObjectMeta.Labels == nil {
+		pod.ObjectMeta.Labels = map[string]string{}
 	}
 
 	// Add vl3 annotation to pod template

--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -202,6 +202,9 @@ func MutateDeployment(deploy *appsv1.Deployment, sliceName string) *appsv1.Deplo
 	annotations[nsmInjectAnnotaionKey1] = "vl3-service-" + sliceName
 	annotations[nsmInjectAnnotaionKey2] = fmt.Sprintf("kernel://vl3-service-%s/nsm0", sliceName)
 
+	if deploy.Spec.Template.ObjectMeta.Labels == nil {
+		deploy.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
 	// Add slice identifier labels to pod template
 	labels := deploy.Spec.Template.ObjectMeta.Labels
 	labels[PodInjectLabelKey] = "app"
@@ -223,6 +226,9 @@ func MutateStatefulset(ss *appsv1.StatefulSet, sliceName string) *appsv1.Statefu
 	annotations[nsmInjectAnnotaionKey1] = "vl3-service-" + sliceName
 	annotations[nsmInjectAnnotaionKey2] = fmt.Sprintf("kernel://vl3-service-%s/nsm0", sliceName)
 
+	if ss.Spec.Template.ObjectMeta.Labels == nil {
+		ss.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
 	// Add slice identifier labels to pod template
 	labels := ss.Spec.Template.ObjectMeta.Labels
 	labels[PodInjectLabelKey] = "app"
@@ -244,6 +250,9 @@ func MutateDaemonSet(ds *appsv1.DaemonSet, sliceName string) *appsv1.DaemonSet {
 	annotations[nsmInjectAnnotaionKey1] = "vl3-service-" + sliceName
 	annotations[nsmInjectAnnotaionKey2] = fmt.Sprintf("kernel://vl3-service-%s/nsm0", sliceName)
 
+	if ds.Spec.Template.ObjectMeta.Labels == nil {
+		ds.Spec.Template.ObjectMeta.Labels = map[string]string{}
+	}
 	// Add slice identifier labels to pod template
 	labels := ds.Spec.Template.ObjectMeta.Labels
 	labels[PodInjectLabelKey] = "app"


### PR DESCRIPTION
This PR fixes nil pointer dereference issues if label field for object is empty.

Issue was observed with the following error message: 
Error from server (InternalError): error when creating "/private/var/folders/79/1qpw4sq56h93prvrqhmj6p7m0000gn/T/1ae182ebc8f383cb5affcef7da4a38fa/resource.yaml": Internal error occurred: failed calling webhook "webhook.kubeslice.io": failed to call webhook: Post "[https://kubeslice-webhook-service.kubeslice-system.svc:443/mutate-webhook?timeout=10s](https://kubeslice-webhook-service.kubeslice-system.svc/mutate-webhook?timeout=10s)": EOF 

This was due to trying to de-reference a nil object in the webhook code. 
Fixes issues with pod,deployment,statefulset and daemonset objects having no labels (i.e nil Label object)