### PR TITLE
feat(SliceGwReconciler): Add `PodDisruptionBudget` logic to `SliceGwReconciler` (#308)

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -290,6 +290,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - list
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/controllers/slicegateway/pod_disruption_budget.go
+++ b/controllers/slicegateway/pod_disruption_budget.go
@@ -1,0 +1,61 @@
+package slicegateway
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeslice/worker-operator/controllers"
+	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Default minAvailable value in PodDisruptionBudget
+var DefaultMinAvailablePodsInPDB = intstr.FromInt(1)
+
+// constructPodDisruptionBudget creates the PodDisruptionBudget's manifest with labels matching the slice gateway pods.
+func constructPodDisruptionBudget(sliceName, sliceGwName string, minAvailable intstr.IntOrString) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-pdb", sliceGwName),
+			Namespace: controllers.ControlPlaneNamespace,
+			Labels: map[string]string{
+				controllers.ApplicationNamespaceSelectorLabelKey: sliceName,
+				controllers.SliceGatewaySelectorLabelKey:         sliceGwName,
+			},
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					controllers.ApplicationNamespaceSelectorLabelKey: sliceName,
+					webhook.PodInjectLabelKey:                        "slicegateway",
+					controllers.SliceGatewaySelectorLabelKey:         sliceGwName,
+				},
+			},
+		},
+	}
+}
+
+// listPodDisruptionBudgetForSliceGateway lists the PodDisruptionBudget objects that match the slice gateway pods.
+func listPodDisruptionBudgetForSliceGateway(ctx context.Context, kubeClient client.Client,
+	sliceName, sliceGwName string) ([]policyv1.PodDisruptionBudget, error) {
+	// Options for listing the PDBs that match the slice and slice gateway
+	listOpts := []client.ListOption{
+		client.MatchingLabels(map[string]string{
+			controllers.ApplicationNamespaceSelectorLabelKey: sliceName,
+			controllers.SliceGatewaySelectorLabelKey:         sliceGwName,
+		}),
+		client.InNamespace(controllers.ControlPlaneNamespace),
+	}
+
+	// List PDBs from cluster that match the slice and slice gateway
+	pdbList := policyv1.PodDisruptionBudgetList{}
+	if err := kubeClient.List(ctx, &pdbList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	return pdbList.Items, nil
+}

--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -29,6 +29,7 @@ import (
 	webhook "github.com/kubeslice/worker-operator/pkg/webhook/pod"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,6 +79,7 @@ type SliceGwReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch;
+//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=list;create;delete
 
 func (r *SliceGwReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var sliceGwNodePorts []int
@@ -490,6 +492,7 @@ func (r *SliceGwReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kubeslicev1beta1.SliceGateway{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.findSliceGwObjectsToReconcile),


### PR DESCRIPTION
# Description
A `PodDisruptionBedget` is required that matches the slice gateway pods, and to specify a minimum availability of 1 pod in case of disruptions.

The `SliceGwReconciler` handles the lifecycle of this `PodDisruptionBudget` object.

Added RBAC permissions for `SliceGwReconciler` to maintain `PodDisruptionBudget`.

Fixes #308

## How Has This Been Tested?

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
    - Since the change is user facing, i.e., the PDB is one extra resource that will be visible to users, I think it is better to a add some explanation in the documentation.
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [x] I have updated the helm chart as required by this PR.
    - Updated the RBAC permissions for CRUD on PodDisruptionBudget objects. However, a PR for the same has to be created once this is approved.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [x] I have verified the E2E test cases with new code changes.
* [x] I have added all the required E2E test cases.
    - Added 3 subtest cases under spoke tests.

## Does this PR introduce a breaking change?

```release-note

```

## Steps to test
1. Deploy the whole setup controller and 2 workers. Check if there are slice gateway pods similar to this in both the worker clusters:
```
water-kind-kubeslice-worker-2-kind-kubeslice-worker-1-0-0-6tqrk   3/3     Running   0          61m
water-kind-kubeslice-worker-2-kind-kubeslice-worker-1-1-0-h4vsp   3/3     Running   0          61m
```
2. With this change, there should also be a `PodDisruptionBudget` created in the same namespace
```
water-kind-kubeslice-worker-2-kind-kubeslice-worker-1-pdb   1               N/A               1                     62m
```
with labels similar to:
```
labels:
  kubeslice.io/slice: water
  kubeslice.io/slice-gw: water-kind-kubeslice-worker-2-kind-kubeslice-worker-1
```
3. When trying to disrupt the node, say one of the worker cluster's worker nodes (if having multi-node setup), using the command:
```
kubectl drain --ignore-daemonsets --delete-emptydir-data <worker-node-name-here>
```
it should be able to evict one pod but fail to evict the other:
```
pod/water-kind-kubeslice-worker-2-kind-kubeslice-worker-1-0-0-6tqrk evicted

error when evicting pods/"water-kind-kubeslice-worker-2-kind-kubeslice-worker-1-1-0-h4vsp" -n "kubeslice-system" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```