### PR TITLE
fix(WebhookServer): Fix webhook EOF error when creating resources (#338)

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	nsmv1 "github.com/networkservicemesh/sdk-k8s/pkg/tools/k8s/apis/networkservicemesh.io/v1"
 	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -136,6 +137,7 @@ func main() {
 			Handler: &podwh.WebhookServer{
 				Client:          mgr.GetClient(),
 				SliceInfoClient: podwh.NewWebhookClient(),
+				Decoder:         admission.NewDecoder(mgr.GetScheme()),
 			},
 		})
 	}

--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -56,14 +56,14 @@ type SliceInfoProvider interface {
 
 type WebhookServer struct {
 	Client          client.Client
-	decoder         *admission.Decoder
+	Decoder         *admission.Decoder
 	SliceInfoClient SliceInfoProvider
 }
 
 func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admission.Response {
 	if req.Kind.Kind == "Pod" {
 		pod := &corev1.Pod{}
-		err := wh.decoder.Decode(req, pod)
+		err := wh.Decoder.Decode(req, pod)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -90,7 +90,7 @@ func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admi
 	} else if req.Kind.Kind == "Deployment" {
 		deploy := &appsv1.Deployment{}
 		log := logger.FromContext(ctx)
-		err := wh.decoder.Decode(req, deploy)
+		err := wh.Decoder.Decode(req, deploy)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -110,7 +110,7 @@ func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admi
 		return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
 	} else if req.Kind.Kind == "StatefulSet" {
 		statefulset := &appsv1.StatefulSet{}
-		err := wh.decoder.Decode(req, statefulset)
+		err := wh.Decoder.Decode(req, statefulset)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -131,7 +131,7 @@ func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admi
 		return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
 	} else if req.Kind.Kind == "DaemonSet" {
 		daemonset := &appsv1.DaemonSet{}
-		err := wh.decoder.Decode(req, daemonset)
+		err := wh.Decoder.Decode(req, daemonset)
 		if err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
@@ -157,11 +157,6 @@ func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admi
 			Message: "Invalid Kind",
 		},
 	}}
-}
-
-func (wh *WebhookServer) InjectDecoder(d *admission.Decoder) error {
-	wh.decoder = d
-	return nil
 }
 
 func MutatePod(pod *corev1.Pod, sliceName string) *corev1.Pod {


### PR DESCRIPTION
# Description
Assign the `decoder` field directly during the initialization of `WebhookServer` in the main package.

Remove the `InjectDecoder` method on `WebhookServer` as the `controller-runtime` package no longer allows injections.

Fixes #338

## How Has This Been Tested?
This is an error with initialization and cannot be tested as a feature.

Steps to test this manually are in #338.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```
