### PR TITLE
fix(AM-13396): fix app & dns pods related errors

### DIFF
--- a/controllers/slice/reconciler.go
+++ b/controllers/slice/reconciler.go
@@ -144,10 +144,12 @@ func (r *SliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return result, err
 	}
 
-	if slice.Status.DNSIP == "" {
-		requeue, result, err := r.handleDnsSvc(ctx, slice)
-		if requeue {
-			return result, err
+	if slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode != v1alpha1.NONET {
+		if slice.Status.DNSIP == "" {
+			requeue, result, err := r.handleDnsSvc(ctx, slice)
+			if requeue {
+				return result, err
+			}
 		}
 	}
 
@@ -187,12 +189,18 @@ func (r *SliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return r.handleAppPodStatusChange(appPods, slice, ctx)
 	}
 
-	debugLog.Info("reconciling app pods")
-	res, err, requeue = r.ReconcileAppPod(ctx, slice)
-	if err != nil {
-		log.Error(err, "App pod reconciliation failed")
-		return res, err
+	if slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode == v1alpha1.NONET {
+		debugLog.Info("No communication slice, skipping reconciliation of apppods")
+		// to support net to no-net switching write a function to remove nsm interfaces, ips, labels with nsmip etc from existing app pods
+	} else {
+		debugLog.Info("reconciling app pods")
+		res, err, requeue = r.ReconcileAppPod(ctx, slice)
+		if err != nil {
+			log.Error(err, "App pod reconciliation failed")
+			return res, err
+		}
 	}
+
 	if requeue {
 		// reconciliation success, update the app pod list in controller
 		log.Info("updating app pod list in hub workersliceconfig status")
@@ -373,9 +381,11 @@ func (r *SliceReconciler) handleSliceDeletion(slice *kubeslicev1beta1.Slice, ctx
 	} else {
 		if controllerutil.ContainsFinalizer(slice, sliceFinalizer) {
 			log.Info("Deleting slice", "slice", slice.Name)
-			err := r.SendSliceDeletionEventToNetOp(ctx, req.NamespacedName.Name, req.NamespacedName.Namespace)
-			if err != nil {
-				log.Error(err, "Failed to send slice deletetion event to netop")
+			if slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode != v1alpha1.NONET {
+				err := r.SendSliceDeletionEventToNetOp(ctx, req.NamespacedName.Name, req.NamespacedName.Namespace)
+				if err != nil {
+					log.Error(err, "Failed to send slice deletetion event to netop")
+				}
 			}
 			if err := r.cleanupSliceResources(ctx, slice); err != nil {
 				log.Error(err, "error while deleting slice")

--- a/controllers/slice/utils.go
+++ b/controllers/slice/utils.go
@@ -37,7 +37,8 @@ func (r *SliceReconciler) cleanupSliceResources(ctx context.Context, slice *kube
 		return err
 	}
 	// the crd itself will be absent for no communication slice. skip!
-	if slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode != v1alpha1.NONET {
+	if slice.Status.SliceConfig != nil &&
+		slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode != v1alpha1.NONET {
 		//cleanup slice router network service
 		if err := r.cleanupVl3NSE(ctx, slice.Name); err != nil {
 			return err

--- a/controllers/slice/utils.go
+++ b/controllers/slice/utils.go
@@ -21,6 +21,7 @@ package slice
 import (
 	"context"
 
+	"github.com/kubeslice/apis/pkg/controller/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/controllers"
 	corev1 "k8s.io/api/core/v1"
@@ -35,9 +36,12 @@ func (r *SliceReconciler) cleanupSliceResources(ctx context.Context, slice *kube
 	if err := r.cleanupSliceNamespaces(ctx, slice); err != nil {
 		return err
 	}
-	//cleanup slice router network service
-	if err := r.cleanupVl3NSE(ctx, slice.Name); err != nil {
-		return err
+	// the crd itself will be absent for no communication slice. skip!
+	if slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode != v1alpha1.NONET {
+		//cleanup slice router network service
+		if err := r.cleanupVl3NSE(ctx, slice.Name); err != nil {
+			return err
+		}
 	}
 	//cleanup Service Discovery objects - serviceimport and export objects that belong to this slice
 	if err := r.cleanupServiceDiscoveryObjects(ctx, slice.Name); err != nil {

--- a/tests/spoke/slice_controller_test.go
+++ b/tests/spoke/slice_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"time"
 
+	controllerv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	. "github.com/onsi/ginkgo/v2"
@@ -103,6 +104,19 @@ var _ = Describe("SliceController", func() {
 
 			sliceKey := types.NamespacedName{Name: "test-slice", Namespace: "kubeslice-system"}
 			createdSlice := &kubeslicev1beta1.Slice{}
+
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, sliceKey, createdSlice)
+				if err != nil {
+					return err
+				}
+				createdSlice.Status = kubeslicev1beta1.SliceStatus{
+					SliceConfig: &kubeslicev1beta1.SliceConfig{
+						SliceOverlayNetworkDeploymentMode: controllerv1alpha1.SINGLENET,
+					},
+				}
+				return k8sClient.Status().Update(ctx, createdSlice)
+			}).Should(Succeed())
 
 			// Make sure slice status.Status.DNSIP is pointing to correct serviceIP
 			Eventually(func() string {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #AM-13396 <!-- Mention any issues which might be fixed on this PR merge. -->

- resolved app pod & kubeslice dns pod not found error
- clean up cni subnets from cluster object when kubeslice networking is disabled

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
