### PR TITLE
fix(): Fixed tunnel status reporting in the slicegw CR

### DIFF
--- a/api/v1beta1/slicegateway_types.go
+++ b/api/v1beta1/slicegateway_types.go
@@ -132,9 +132,14 @@ type GwPodInfo struct {
 	PeerPodName           string       `json:"peerPodName,omitempty"`
 	PodIP                 string       `json:"podIP,omitempty"`
 	LocalNsmIP            string       `json:"localNsmIP,omitempty"`
-	TunnelStatus          TunnelStatus `json:"tunnelStatus,omitempty"`
-	RouteRemoved          int32        `json:"routeRemoved,omitempty"`
+	// TunnelStatus is the status of the tunnel between this gw pod and its peer
+	TunnelStatus TunnelStatus `json:"tunnelStatus,omitempty"`
+	RouteRemoved int32        `json:"routeRemoved,omitempty"`
+	// RemotePort is the port number this gw pod is connected to on the remote cluster.
+	// Applicable only for gw clients. Would be set to 0 for gw servers.
+	RemotePort int32 `json:"remotePort,omitempty"`
 }
+
 type TunnelStatus struct {
 	IntfName   string `json:"IntfName,omitempty"`
 	LocalIP    string `json:"LocalIP,omitempty"`
@@ -143,7 +148,10 @@ type TunnelStatus struct {
 	TxRate     uint64 `json:"TxRate,omitempty"`
 	RxRate     uint64 `json:"RxRate,omitempty"`
 	PacketLoss uint64 `json:"PacketLoss,omitempty"`
-	Status     int32  `json:"Status,omitempty"`
+	// Status is the status of the tunnel. 0: DOWN, 1: UP
+	Status int32 `json:"Status,omitempty"`
+	// TunnelState is the state of the tunnel in string format: UP, DOWN, UNKNOWN
+	TunnelState string `json:"TunnelState,omitempty"`
 }
 
 func init() {

--- a/config/crd/bases/networking.kubeslice.io_slicegateways.yaml
+++ b/config/crd/bases/networking.kubeslice.io_slicegateways.yaml
@@ -169,10 +169,18 @@ spec:
                       type: string
                     podName:
                       type: string
+                    remotePort:
+                      description: |-
+                        RemotePort is the port number this gw pod is connected to on the remote cluster.
+                        Applicable only for gw clients. Would be set to 0 for gw servers.
+                      format: int32
+                      type: integer
                     routeRemoved:
                       format: int32
                       type: integer
                     tunnelStatus:
+                      description: TunnelStatus is the status of the tunnel between
+                        this gw pod and its peer
                       properties:
                         IntfName:
                           type: string
@@ -190,8 +198,14 @@ spec:
                           format: int64
                           type: integer
                         Status:
+                          description: 'Status is the status of the tunnel. 0: DOWN,
+                            1: UP'
                           format: int32
                           type: integer
+                        TunnelState:
+                          description: 'TunnelState is the state of the tunnel in
+                            string format: UP, DOWN, UNKNOWN'
+                          type: string
                         TxRate:
                           format: int64
                           type: integer


### PR DESCRIPTION
The gw tunnel status is recorded in the slicegateway CR status field. There are a number of fields like the interface name, rx and tx rates, latency and pkt loss in the status field but not all of them are getting filled. This is occurring because of an incorrect type conversion between gwpod.TunnelStatus and gwsidecar.TunnelStatus. The former struct is what is written to the status field of the CR and the latter is the struct that is filled by the grpc messaging between the operator and the gw sidecar. 

The code changes in this PR address the above issue. It also adds additional info in the status field of the CR like the remote port number an instance of gw client is connecting to, and the tunnel state in string format for ease of debugging. The code also contains a couple of fixes for issues reported by the Go static analysis tool: removed unnecessary input params from a couple of functions and updated error messages to start with lowercase.