### PR TITLE
fix(): configurable ns exclusion list

### DIFF
--- a/pkg/namespace/controllers/reconciler.go
+++ b/pkg/namespace/controllers/reconciler.go
@@ -19,6 +19,7 @@ package namespace
 
 import (
 	"context"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
@@ -48,8 +49,7 @@ type Reconciler struct {
 	Hubclient     *hub.HubClientConfig
 }
 
-var excludedNs = []string{"kube-system", "default", "kubeslice-system", "kube-node-lease",
-	"kube-public", "istio-system"}
+var excludedNs []string
 
 var controllerName string = "namespaceReconciler"
 
@@ -68,6 +68,9 @@ func (c *Reconciler) getSliceNameFromNs(ns string) (string, error) {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+
+	excludedNsEnv := utils.GetEnvOrDefault("EXCLUDED_NS", "kube-system,default,kubeslice-system,kube-node-lease,kube-public,istio-system")
+	excludedNs = strings.Split(excludedNsEnv, ",")
 	for _, v := range excludedNs {
 		if v == req.Name {
 			return ctrl.Result{}, nil

--- a/pkg/namespace/controllers/reconciler.go
+++ b/pkg/namespace/controllers/reconciler.go
@@ -69,7 +69,7 @@ func (c *Reconciler) getSliceNameFromNs(ns string) (string, error) {
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
-	excludedNsEnv := utils.GetEnvOrDefault("EXCLUDED_NS", "kube-system,default,kubeslice-system,kube-node-lease,kube-public,istio-system")
+	excludedNsEnv := utils.GetEnvOrDefault("EXCLUDED_NS", utils.DefaultExcludedNS)
 	excludedNs = strings.Split(excludedNsEnv, ",")
 	for _, v := range excludedNs {
 		if v == req.Name {

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,6 +1,7 @@
 package utils
 
 const (
-	NotApplicable = "NA"
-	EventsVersion = "v1alpha1"
+	NotApplicable     = "NA"
+	EventsVersion     = "v1alpha1"
+	DefaultExcludedNS = "kube-system,default,kubeslice-system,kube-node-lease,kube-public,istio-system"
 )


### PR DESCRIPTION
# Description
This provides a configurable way to provide a list of namespaces to be excluded in namespace reconcilers. It can be passed through an environment variable. If not provided a default list would be used.

Fixes # <!-- Mention any issues which might be fixed on this PR merge. -->

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
