### PR TITLE
fix(): offboard ns when invalid labels are applied to ns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 ##########################################################
 
 # Build the manager binary
-FROM golang:1.22.1 as builder
+FROM golang:1.23.1 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ dockerbuildtestPipeline(
   service: 'worker-operator',
   buildArguments: [PLATFORM:"amd64"],
   run_unit_tests: 'false',
-  ignore_critical: 'true'
+  ignore_critical: 'false'
   
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,8 @@ dockerbuildtestPipeline(
   service: 'worker-operator',
   buildArguments: [PLATFORM:"amd64"],
   run_unit_tests: 'false',
-  ignore_critical: 'false'
+  ignore_critical: 'false',
+  update_trivy: 'false'
   
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,8 @@ dockerbuildtestPipeline(
   script: this,
   service: 'worker-operator',
   buildArguments: [PLATFORM:"amd64"],
-  run_unit_tests: 'false'
+  run_unit_tests: 'false',
+  ignore_critical: 'true'
   
 )
 

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -98,6 +98,7 @@ func GetSliceGatewayServers(ctx context.Context, c client.Client, sliceName stri
 func GetSliceGwServices(ctx context.Context, c client.Client, sliceName string) (*corev1.ServiceList, error) {
 	sliceGwSvcList := &corev1.ServiceList{}
 	listOpts := []client.ListOption{
+		client.InNamespace(ControlPlaneNamespace),
 		client.MatchingLabels(map[string]string{ApplicationNamespaceSelectorLabelKey: sliceName}),
 	}
 

--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -48,7 +48,18 @@ const (
 )
 
 var (
-	log = logger.NewWrappedLogger().WithName("Webhook").V(1)
+	log            = logger.NewWrappedLogger().WithName("Webhook").V(1)
+	LabelsToRemove = []string{
+		"kubeslice.io/nsmIP",
+		"kubeslice.io/pod-type",
+		"kubeslice.io/slice",
+	}
+
+	AnnotationsToRemove = []string{
+		"kubeslice.io/status",
+		"ns.networkservicemesh.io",
+		"networkservicemesh.io",
+	}
 )
 
 type SliceInfoProvider interface {
@@ -199,33 +210,25 @@ func (wh *WebhookServer) OffBoardObject(metadata metav1.ObjectMeta, ctx context.
 	annotations := metadata.GetAnnotations()
 	labels := metadata.GetLabels()
 
-	//TODO:
-	// 		a. if not part of slice but has kubeslice or nsm labels -> yes ? remove them
-	//			i.   remove labels
-	//TODO: move as global variable
 	// Remove kubeslice and nsm labels if present
-	//TODO: use constants
-	labelsToRemove := []string{"kubeslice.io/nsmIP", "kubeslice.io/pod-type", "kubeslice.io/slice"}
-	for _, labelKey := range labelsToRemove {
+	LabelsToRemove := []string{"kubeslice.io/nsmIP", "kubeslice.io/pod-type", "kubeslice.io/slice"}
+	for _, labelKey := range LabelsToRemove {
 		if _, exists := labels[labelKey]; exists {
 			log.Info("Removing label", "labelKey", labelKey)
 			delete(labels, labelKey)
 		}
 	}
 	metadata.SetLabels(labels)
-	//TODO:			ii.  remove annotations
-	//TODO: move as global variable
+
 	// Remove annotations if necessary
-	//TODO: use constants
-	annotationsToRemove := []string{"kubeslice.io/status", "ns.networkservicemesh.io", "networkservicemesh.io"}
-	for _, annotationKey := range annotationsToRemove {
+	AnnotationsToRemove := []string{"kubeslice.io/status", "ns.networkservicemesh.io", "networkservicemesh.io"}
+	for _, annotationKey := range AnnotationsToRemove {
 		if _, exists := annotations[annotationKey]; exists {
 			log.Info("Removing annotation", "annotationKey", annotationKey)
 			delete(annotations, annotationKey)
 		}
 	}
 	metadata.SetAnnotations(annotations)
-	//TODO			iii. remove containers
 	return metadata
 }
 
@@ -374,13 +377,7 @@ func (wh *WebhookServer) OffboardRequired(metadata metav1.ObjectMeta, ctx contex
 	annotations := metadata.GetAnnotations()
 	labels := metadata.GetLabels()
 
-	//TODO:
-	// 		a. if not part of slice but has kubeslice or nsm labels -> yes ? remove them
-	//			i.   remove labels
-	//			ii.  remove annotations
-	//TODO: move as global variable
 	// Remove kubeslice and nsm labels if present
-	//TODO: use constants
 	if sliceNameInNs, exists := labels[admissionWebhookSliceNamespaceSelectorKey]; exists {
 		log.Info("slice name in namespace exists", "sliceNameInNs", sliceNameInNs)
 		if sliceNameInNs != sliceName {
@@ -400,19 +397,17 @@ func (wh *WebhookServer) OffboardRequired(metadata metav1.ObjectMeta, ctx contex
 		return false
 	}
 
-	labelsToRemove := []string{"kubeslice.io/nsmIP", "kubeslice.io/pod-type", "kubeslice.io/slice"}
-	for _, labelKey := range labelsToRemove {
+	LabelsToRemove := []string{"kubeslice.io/nsmIP", "kubeslice.io/pod-type", "kubeslice.io/slice"}
+	for _, labelKey := range LabelsToRemove {
 		if _, exists := labels[labelKey]; exists {
 			log.Info("Found label", "labelKey", labelKey)
 			return true
 		}
 	}
 
-	//TODO: move as global variable
 	// Remove annotations if necessary
-	//TODO: use constants
-	annotationsToRemove := []string{"kubeslice.io/status", "ns.networkservicemesh.io", "networkservicemesh.io"}
-	for _, annotationKey := range annotationsToRemove {
+	AnnotationsToRemove := []string{"kubeslice.io/status", "ns.networkservicemesh.io", "networkservicemesh.io"}
+	for _, annotationKey := range AnnotationsToRemove {
 		if _, exists := annotations[annotationKey]; exists {
 			log.Info("Found annotation", "annotationKey", annotationKey)
 			return true

--- a/pkg/webhook/pod/webhook.go
+++ b/pkg/webhook/pod/webhook.go
@@ -82,7 +82,7 @@ func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admi
 			log.Info("mutation not required for pod", "pod metadata", pod.ObjectMeta.Name)
 			if offBoard := wh.OffboardRequired(pod.ObjectMeta, ctx, req.Kind.Kind); offBoard {
 				log.Info("mutation to offboard required for pod", "pod metadata", pod.ObjectMeta.Name)
-				pod = OffBoardPod(pod, ctx)
+				pod = wh.OffBoardPod(pod, ctx)
 			}
 		} else {
 			log.Info("mutating pod", "pod metadata", pod.ObjectMeta.Name)
@@ -181,7 +181,7 @@ func (wh *WebhookServer) Handle(ctx context.Context, req admission.Request) admi
 	}}
 }
 
-func OffBoardPod(pod *corev1.Pod, ctx context.Context) *corev1.Pod {
+func (wh *WebhookServer) OffBoardPod(pod *corev1.Pod, ctx context.Context) *corev1.Pod {
 	log := logger.FromContext(ctx)
 
 	metadata := pod.ObjectMeta


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
When a namespace is applied labels and/or annotations that are not part of the sliceconfig spec, 
worker operator does remove the labels/annotations and hence, the workloads may come up with unnecessary labels/annotations. 
This issue is now fixed under the changes in this PR
Fixes # <!-- Mention any issues which might be fixed on this PR merge. -->

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->
test-cases
- [X] namespace with the kubeslice labels but not part of any sliceconfig is offboarded
- [X] namespace with the kubeslice annotations but not part of any sliceconfig is offboarded
- [X] namespace with valid kubeslice labels/annotations work as expected
- [X] namespace when replicated from cluster "worker-1" having valid sliceconfig to another cluster "worker-2", the workloads do not have invalid kubeslice labels/annotations

## Checklist:

* [X] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [X] I have ran `go fmt`
* [X] I have updated the helm chart as required by this PR.
* [X] I have performed a self-review of my own code.
* [X] I have commented my code, particularly in hard-to-understand areas.
* [X] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [X] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
