### PR TITLE
fix: svcexp getting stuck, index out of range during gw recycle

### DIFF
--- a/controllers/serviceexport/reconciler.go
+++ b/controllers/serviceexport/reconciler.go
@@ -218,7 +218,7 @@ func isValidNameSpace(ns string, slice *kubeslicev1beta1.Slice) bool {
 	if ns == fmt.Sprintf(sliceController.VPC_NS_FMT, slice.Name) {
 		return true
 	}
-	return arrayContainsString(slice.Status.ApplicationNamespaces, ns)
+	return arrayContainsString(slice.Status.SliceConfig.NamespaceIsolationProfile.ApplicationNamespaces, ns)
 }
 
 // Setup ServiceExport Reconciler

--- a/controllers/slicegateway/utils.go
+++ b/controllers/slicegateway/utils.go
@@ -357,6 +357,9 @@ func GetPodForGwDeployment(ctx context.Context, c client.Client, depName string)
 	if err := c.List(ctx, &podList, listOpts...); err != nil {
 		return nil, err
 	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("No pods found with matching labels")
+	}
 
 	return &podList.Items[0], nil
 }


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes 
- Service Export reconciler getting stuck on empty application namespace in slice status
- WorkerSliceGwRecycler panics due to index out of range during slice gateway recycle

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
