### PR TITLE
fix(): Avoid unnecessary reconcile cycles for slice gw

### DIFF
--- a/controllers/vars.go
+++ b/controllers/vars.go
@@ -37,6 +37,11 @@ var (
 	ImagePullSecretName = utils.GetEnvOrDefault("IMAGE_PULL_SECRET_NAME", "kubeslice-nexus")
 
 	ReconcileInterval = 10 * time.Second
+	// This value is the periodic reconcile interval for slicegateway CRs. The slicegateway CRD reconciler is set up to
+	// be event driven. In addition to being triggered due to updates to the slicegateway CR objects, it is also invoked
+	// in an event driven manner whenever important pods like the slice router, slice gw pods, and other critical infra
+	// pods restart. Hence, it does not really need an aggressive periodic reconcile interval.
+	SliceGatewayReconcileInterval = 120 * time.Second
 )
 
 const (

--- a/pkg/hub/hubclient/hubclient.go
+++ b/pkg/hub/hubclient/hubclient.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -38,6 +37,7 @@ import (
 	hubv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
 	spokev1alpha1 "github.com/kubeslice/apis/pkg/worker/v1alpha1"
 	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
+	hubutils "github.com/kubeslice/worker-operator/pkg/hub"
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	"github.com/kubeslice/worker-operator/pkg/monitoring"
 )
@@ -168,8 +168,8 @@ func (hubClient *HubClientConfig) UpdateNodePortForSliceGwServer(ctx context.Con
 		return err
 	}
 
-	if reflect.DeepEqual(sliceGw.Spec.LocalGatewayConfig.NodePorts, sliceGwNodePorts) {
-		// No update needed
+	// If the node ports on the controller cluster and the worker are the same, no need to update
+	if hubutils.ListEqual(sliceGw.Spec.LocalGatewayConfig.NodePorts, sliceGwNodePorts) {
 		return nil
 	}
 

--- a/pkg/hub/utils.go
+++ b/pkg/hub/utils.go
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2025 Avesha, Inc. All rights reserved.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package hubutils
+
+func ListContains[T comparable](li []T, v T) bool {
+	for _, val := range li {
+		if val == v {
+			return true
+		}
+	}
+	return false
+}
+
+func ListEqual[T comparable](l1, l2 []T) bool {
+	if len(l1) != len(l2) {
+		return false
+	}
+	for _, val := range l1 {
+		if !ListContains(l2, val) {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
The slice gw reconciler is in a perpetual reconcile cycle. There are places where the CR update func is being called in a for loop. And reflect.DeepEqual is being used to compare two lists that are never guaranteed to have their elements in the same order, this causes unnecessary update from the server worker cluster to the controller, which triggers an update on the client cluster. The reconciler also watches for node updates blindly, triggering the reconcile func every time there is an update to the Node object. The update could be because of the cluster provider adding or modifying labels and annotations. We need a granular check on the node update and trigger the reconciler func only if needed.

Due to the reconcile storm, updates are not being handled in a timely manner, and sometimes it is so bad that the reconcile events get queued for days. This was observed on a customer cluster where an update to the CR was not handled for 15 days.