### PR TITLE
fix(): Added missing resources and fix SecurityContext for OpenVPN gateway containers

### DIFF
--- a/controllers/slicegateway/slicegateway.go
+++ b/controllers/slicegateway/slicegateway.go
@@ -273,12 +273,25 @@ func (r *SliceGwReconciler) deploymentForGatewayServer(g *kubeslicev1beta1.Slice
 								Add: []corev1.Capability{
 									"NET_ADMIN",
 								},
+								Drop: []corev1.Capability{
+									"ALL",
+								},
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "shared-volume",
 							MountPath: "/etc/openvpn",
 						}},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"memory": resource.MustParse("256Mi"),
+								"cpu":    resource.MustParse("200m"),
+							},
+							Requests: corev1.ResourceList{
+								"memory": resource.MustParse("128Mi"),
+								"cpu":    resource.MustParse("100m"),
+							},
+						},
 					}},
 					Volumes: []corev1.Volume{
 						{
@@ -558,12 +571,25 @@ func (r *SliceGwReconciler) deploymentForGatewayClient(g *kubeslicev1beta1.Slice
 								Add: []corev1.Capability{
 									"NET_ADMIN",
 								},
+								Drop: []corev1.Capability{
+									"ALL",
+								},
 							},
 						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "shared-volume",
 							MountPath: "/vpnclient",
 						}},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"memory": resource.MustParse("128Mi"),
+								"cpu":    resource.MustParse("100m"),
+							},
+							Requests: corev1.ResourceList{
+								"memory": resource.MustParse("64Mi"),
+								"cpu":    resource.MustParse("50m"),
+							},
+						},
 					}},
 					Volumes: []corev1.Volume{{
 						Name: "shared-volume",


### PR DESCRIPTION
## Description
This PR fixes missing resource specifications and overly permissive security contexts in OpenVPN gateway containers within slice gateway pod specifications.

Fixes: #363 , #364 , #365 , #366 

**Changes Made:**
- Added resource limits and requests for OpenVPN server (256Mi memory, 200m CPU)
- Added resource limits and requests for OpenVPN client (128Mi memory, 100m CPU)  
- Updated SecurityContext for both containers to use minimum required permissions

## How Has This Been Tested?
Tested with KubeSlice minimal-demo setup. Verified that gateway pods now have proper resource specs and security improvements without breaking functionality.

## Checklist:
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [x] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
