### PR TITLE
fix(): Added gRPC port configuration & updated sidecar container SecurityContext

### DIFF
--- a/controllers/slicegateway/slicegateway.go
+++ b/controllers/slicegateway/slicegateway.go
@@ -225,12 +225,19 @@ func (r *SliceGwReconciler) deploymentForGatewayServer(g *kubeslicev1beta1.Slice
 								Value: "config",
 							},
 						},
+						Ports: []corev1.ContainerPort{{
+							Name:          "grpc",
+							ContainerPort: 5000,
+						}},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               &privileged,
 							AllowPrivilegeEscalation: &privileged,
 							Capabilities: &corev1.Capabilities{
 								Add: []corev1.Capability{
 									"NET_ADMIN",
+								},
+								Drop: []corev1.Capability{
+									"ALL",
 								},
 							},
 						},
@@ -520,12 +527,19 @@ func (r *SliceGwReconciler) deploymentForGatewayClient(g *kubeslicev1beta1.Slice
 								Value: strconv.Itoa(remotePortNumber),
 							},
 						},
+						Ports: []corev1.ContainerPort{{
+							Name:          "grpc",
+							ContainerPort: 5000,
+						}},
 						SecurityContext: &corev1.SecurityContext{
 							Privileged:               &privileged,
 							AllowPrivilegeEscalation: &privileged,
 							Capabilities: &corev1.Capabilities{
 								Add: []corev1.Capability{
 									"NET_ADMIN",
+								},
+								Drop: []corev1.Capability{
+									"ALL",
 								},
 							},
 						},


### PR DESCRIPTION
## Description
Added missing ContainerPorts in the sidecar container spec  & updated sidecar container SecurityContext

Fixes #361 #362 

**Changes:**
- Added gRPC port configuration (5000) to both server and client sidecar containers
- Updated sidecar container security context with proper capability drops (`Drop: ["ALL"]`)

## How Has This Been Tested?
Tested with KubeSlice minimal-demo setup. Verified that Sidecar containrs now properly expose gRPC port (5000) & sidecar container SecurityContext requests only needed permissions

## Checklist:
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [x] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
