### PR TITLE
fix(): Optimize NetworkPolicy reconciler to reduce unnecessary API update calls and reduce log noise

### DIFF
--- a/controllers/slice/namespaces.go
+++ b/controllers/slice/namespaces.go
@@ -696,7 +696,9 @@ func (r *SliceReconciler) reconcileSliceNetworkPolicy(ctx context.Context, slice
 	policiesInstalled := successfulNamespaces > 0
 	if slice.Status.NetworkPoliciesInstalled != policiesInstalled {
 		slice.Status.NetworkPoliciesInstalled = policiesInstalled
-		return r.Status().Update(ctx, slice)
+		if err := r.Status().Update(ctx, slice); err != nil {
+			return err
+		}
 	}
 
 	if len(errors) > 0 {


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
This PR optimizes the NetworkPolicy reconciliation logic with following changes:
- **Conditional NetworkPolicy updates**: Use `equality.Semantic.DeepEqual()` to compare specs and only update when different
- **Reduced logging frequency**: Move logs and events outside the reconciliation loop
- **Smart status updates**: Only update `NetworkPoliciesInstalled` when the field value actually changes
- **Better error handling**: Continue processing all namespaces even if some fail

#### No breaking changes - all existing functionality preserved with improved performance

Fixes #372  <!-- Mention any issues which might be fixed on this PR merge. -->

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
