### PR TITLE
fix: remove duplicate istiov1beta1 scheme registration in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,6 @@ func init() {
 	utilruntime.Must(nsmv1.AddToScheme(scheme))
 	utilruntime.Must(istiov1beta1.AddToScheme(scheme))
 	utilruntime.Must(kubeslicev1beta1.AddToScheme(scheme))
-	utilruntime.Must(istiov1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
## What does this PR do?

Removes a duplicate `istiov1beta1.AddToScheme(scheme)` call in the `init()` function of `main.go`.

The istio scheme was being registered twice back-to-back:

```go
utilruntime.Must(istiov1beta1.AddToScheme(scheme))
utilruntime.Must(kubeslicev1beta1.AddToScheme(scheme))
utilruntime.Must(istiov1beta1.AddToScheme(scheme)) // duplicate
```

The second call is a no-op since controller-runtime deduplicates scheme registrations internally, but it looks like a distinct registration was intended — possibly a different API group that was accidentally replaced with a copy of the istio line.

Fixes #472 

## How has this been tested?

- `make fmt` — no changes
- `make vet` — no issues  
- `make build` — builds cleanly

## Checklist

- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR requires documentation updates?
- [x] I have ran go fmt
- [x] I have performed a self-review of my own code.

## Does this PR introduce a breaking change?

No.