### PR TITLE
fix: return nil explicitly in SliceGateway NONET early-exit path

### DIFF
--- a/controllers/slicegateway/reconciler.go
+++ b/controllers/slicegateway/reconciler.go
@@ -134,7 +134,7 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if slice.Status.SliceConfig != nil &&
 		slice.Status.SliceConfig.SliceOverlayNetworkDeploymentMode == v1alpha1.NONET {
 		log.Info("No communication slice. Skipping slicegw reconcilation")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
 	}
 
 	// Check if slice router network service endpoint (NSE) is present before spawning slice gateway pod.


### PR DESCRIPTION
# Description

In `controllers/slicegateway/reconciler.go`, the early-exit path for NONET slices returns `err` instead of `nil`:

```go
// before
return ctrl.Result{}, err

// after  
return ctrl.Result{}, nil
```

At this point in the code, `err` holds the return value from `controllers.GetSlice` which was already checked to be non-nil a few lines above — so it is always `nil` here and behaviour is identical. The problem is that using `err` makes the intent unclear and creates a latent risk: any future refactor that introduces a new `err` assignment between the `GetSlice` call and this NONET guard could silently turn a clean early exit into an unexpected error return.

Fixes #474 

## How Has This Been Tested?

- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```