### PR TITLE
test(hub): add slicegw status sync helpers for WorkerSliceGateway (#470)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Guidelines on how to contribute to KubeSlice
 
-There are a number of ways you can contribute to the KubeSlice project. We would like to accept your patches and contributions to the KubeSlice code base. This document provides guidelines on how to contribute to the KubeSlice code base. We require all participants to adhere to the [Code of Conduct](https://github.com/kubeslice/worker-operator/blob/doc/contributing-guide/code_of_conduct.md).
+There are a number of ways you can contribute to the KubeSlice project. We would like to accept your patches and contributions to the KubeSlice code base. This document provides guidelines on how to contribute to the KubeSlice code base. We require all participants to adhere to the [Code of Conduct](https://github.com/kubeslice/worker-operator/blob/master/code_of_conduct.md).
 
 
 Here are some ways to contribute:
@@ -26,7 +26,7 @@ A signed commit is a commit where the commit message contains the following cont
 This can be done by adding `--signoff` to your git command line
 
 ## Code of Conduct
-Please make sure to read and observe our [Code of Conduct](https://github.com/kubeslice/worker-operator/blob/doc/contributing-guide/code_of_conduct.md).
+Please make sure to read and observe our [Code of Conduct](https://github.com/kubeslice/worker-operator/blob/master/code_of_conduct.md).
 
 ## Contributor Workflow
 
@@ -49,7 +49,7 @@ If you encounter a bug, please file an issue in the Github repository. Please pr
 * Write good [commit messages](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
 
 ## Developer Guide
-This guide helps you to get started with developing [kubeslice-worker](https://github.com/kubeslice/worker-operator/blob/doc/contributing-guide/developer_guide.md).
+This guide helps you to get started with developing [kubeslice-worker](https://github.com/kubeslice/worker-operator/blob/master/developer_guide.md) (`developer_guide.md` in this repository).
 
 ## License
 Apache License 2.0

--- a/pkg/hub/controllers/slicegateway_controller.go
+++ b/pkg/hub/controllers/slicegateway_controller.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubeslice/worker-operator/controllers"
 	ossEvents "github.com/kubeslice/worker-operator/events"
 	hubutils "github.com/kubeslice/worker-operator/pkg/hub"
+	slicegwstatus "github.com/kubeslice/worker-operator/pkg/hub/slicegwstatus"
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	"github.com/kubeslice/worker-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -71,8 +72,8 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	log.Info("got sliceGw from hub", "sliceGw", sliceGw.Name)
 	*r.EventRecorder = (*r.EventRecorder).WithSlice(sliceGw.Spec.SliceName)
 	// Return if the slice gw resource does not belong to our cluster
-	if sliceGw.Spec.LocalGatewayConfig.ClusterName != r.ClusterName {
-		log.Info("sliceGw doesn't belong to this cluster", "sliceGw", sliceGw.Name, "cluster", clusterName, "slicegw cluster", sliceGw.Spec.LocalGatewayConfig.ClusterName)
+	if !slicegwstatus.WorkerSliceGatewayTargetsCluster(sliceGw, r.ClusterName) {
+		log.Info("sliceGw doesn't belong to this cluster", "sliceGw", sliceGw.Name, "cluster", r.ClusterName, "slicegw cluster", sliceGw.Spec.LocalGatewayConfig.ClusterName)
 		return reconcile.Result{}, nil
 	}
 	requeue, result, err := r.handleSliceGWDeletion(sliceGw, ctx, req)
@@ -97,7 +98,6 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	}
 
 	// Update the slicegateway CR on the worker cluster only if something has changed.
-	toUpdate := false
 	sliceGwRef := client.ObjectKey{
 		Name:      sliceGwName,
 		Namespace: ControlPlaneNamespace,
@@ -106,36 +106,16 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	// First check all the static fields.
-	if meshSliceGw.Status.Config.SliceGatewayID != sliceGw.Spec.LocalGatewayConfig.GatewayName ||
-		meshSliceGw.Status.Config.SliceGatewaySubnet != sliceGw.Spec.LocalGatewayConfig.GatewaySubnet ||
-		meshSliceGw.Status.Config.SliceGatewayRemoteSubnet != sliceGw.Spec.RemoteGatewayConfig.GatewaySubnet ||
-		meshSliceGw.Status.Config.SliceGatewayHostType != sliceGw.Spec.GatewayHostType ||
-		meshSliceGw.Status.Config.SliceGatewayRemoteClusterID != sliceGw.Spec.RemoteGatewayConfig.ClusterName ||
-		meshSliceGw.Status.Config.SliceGatewayRemoteGatewayID != sliceGw.Spec.RemoteGatewayConfig.GatewayName ||
-		meshSliceGw.Status.Config.SliceGatewayName != strconv.Itoa(sliceGw.Spec.GatewayNumber) ||
-		meshSliceGw.Status.Config.SliceGatewayConnectivityType != sliceGw.Spec.GatewayConnectivityType ||
-		meshSliceGw.Status.Config.SliceGatewayProtocol != sliceGw.Spec.GatewayProtocol ||
-		meshSliceGw.Status.Config.SliceGatewayType != sliceGw.Spec.GatewayType {
-		toUpdate = true
-	}
-	// If no change in static fields, check the dynamic fields
-	if !toUpdate {
-		// For client type, check the following fields
+	toUpdate := slicegwstatus.MeshSliceGatewayStatusOutOfSync(meshSliceGw, sliceGw)
+	if toUpdate {
 		if meshSliceGw.Status.Config.SliceGatewayHostType == "Client" {
 			if !hubutils.ListEqual(meshSliceGw.Status.Config.SliceGatewayRemoteNodeIPs, sliceGw.Spec.RemoteGatewayConfig.NodeIps) {
 				log.Info("Update from hub: Node IPs changed", "SliceGw", sliceGw.Name, "NodeIPs", sliceGw.Spec.RemoteGatewayConfig.NodeIps)
-				toUpdate = true
 			}
-			// Next check node port
-			if !toUpdate {
-				if !hubutils.ListEqual(meshSliceGw.Status.Config.SliceGatewayNodePorts, sliceGw.Spec.RemoteGatewayConfig.NodePorts) {
-					log.Info("Update from hub: NodePort numbers changed", "SliceGw", sliceGw.Name, "NodePorts", sliceGw.Spec.RemoteGatewayConfig.NodePorts)
-					toUpdate = true
-				}
+			if !hubutils.ListEqual(meshSliceGw.Status.Config.SliceGatewayNodePorts, sliceGw.Spec.RemoteGatewayConfig.NodePorts) {
+				log.Info("Update from hub: NodePort numbers changed", "SliceGw", sliceGw.Name, "NodePorts", sliceGw.Spec.RemoteGatewayConfig.NodePorts)
 			}
 		}
-		// Nothing dynamic to check for the server type
 	}
 
 	if toUpdate {

--- a/pkg/hub/slicegwstatus/sync.go
+++ b/pkg/hub/slicegwstatus/sync.go
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2022 Avesha, Inc. All rights reserved.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Package slicegwstatus holds pure helpers for hub WorkerSliceGateway vs spoke SliceGateway status sync (issue #470 / hub-and-spoke peering groundwork).
+package slicegwstatus
+
+import (
+	"strconv"
+
+	spokev1alpha1 "github.com/kubeslice/apis/pkg/worker/v1alpha1"
+	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
+	hubutils "github.com/kubeslice/worker-operator/pkg/hub"
+)
+
+// WorkerSliceGatewayTargetsCluster returns true when the hub WorkerSliceGateway is intended for this worker cluster.
+func WorkerSliceGatewayTargetsCluster(hubGW *spokev1alpha1.WorkerSliceGateway, localClusterName string) bool {
+	return hubGW.Spec.LocalGatewayConfig.ClusterName == localClusterName
+}
+
+// MeshSliceGatewayStatusOutOfSync returns true when the spoke SliceGateway status.Config should be refreshed from the hub WorkerSliceGateway (static + client remote node fields).
+func MeshSliceGatewayStatusOutOfSync(mesh *kubeslicev1beta1.SliceGateway, hub *spokev1alpha1.WorkerSliceGateway) bool {
+	if mesh.Status.Config.SliceGatewayID != hub.Spec.LocalGatewayConfig.GatewayName ||
+		mesh.Status.Config.SliceGatewaySubnet != hub.Spec.LocalGatewayConfig.GatewaySubnet ||
+		mesh.Status.Config.SliceGatewayRemoteSubnet != hub.Spec.RemoteGatewayConfig.GatewaySubnet ||
+		mesh.Status.Config.SliceGatewayHostType != hub.Spec.GatewayHostType ||
+		mesh.Status.Config.SliceGatewayRemoteClusterID != hub.Spec.RemoteGatewayConfig.ClusterName ||
+		mesh.Status.Config.SliceGatewayRemoteGatewayID != hub.Spec.RemoteGatewayConfig.GatewayName ||
+		mesh.Status.Config.SliceGatewayName != strconv.Itoa(hub.Spec.GatewayNumber) ||
+		mesh.Status.Config.SliceGatewayConnectivityType != hub.Spec.GatewayConnectivityType ||
+		mesh.Status.Config.SliceGatewayProtocol != hub.Spec.GatewayProtocol ||
+		mesh.Status.Config.SliceGatewayType != hub.Spec.GatewayType {
+		return true
+	}
+	if mesh.Status.Config.SliceGatewayHostType == "Client" {
+		if !hubutils.ListEqual(mesh.Status.Config.SliceGatewayRemoteNodeIPs, hub.Spec.RemoteGatewayConfig.NodeIps) {
+			return true
+		}
+		if !hubutils.ListEqual(mesh.Status.Config.SliceGatewayNodePorts, hub.Spec.RemoteGatewayConfig.NodePorts) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hub/slicegwstatus/sync_test.go
+++ b/pkg/hub/slicegwstatus/sync_test.go
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2022 Avesha, Inc. All rights reserved.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package slicegwstatus
+
+import (
+	"testing"
+
+	hubv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
+	spokev1alpha1 "github.com/kubeslice/apis/pkg/worker/v1alpha1"
+	kubeslicev1beta1 "github.com/kubeslice/worker-operator/api/v1beta1"
+)
+
+func TestWorkerSliceGatewayTargetsCluster(t *testing.T) {
+	tests := []struct {
+		name      string
+		local     string
+		reconcile string
+		want      bool
+	}{
+		{
+			name:      "match",
+			local:     "cluster-east",
+			reconcile: "cluster-east",
+			want:      true,
+		},
+		{
+			name:      "wrong cluster ignored",
+			local:     "cluster-west",
+			reconcile: "cluster-east",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hub := &spokev1alpha1.WorkerSliceGateway{
+				Spec: spokev1alpha1.WorkerSliceGatewaySpec{
+					LocalGatewayConfig: spokev1alpha1.SliceGatewayConfig{
+						ClusterName: tt.local,
+					},
+				},
+			}
+			if got := WorkerSliceGatewayTargetsCluster(hub, tt.reconcile); got != tt.want {
+				t.Fatalf("WorkerSliceGatewayTargetsCluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMeshSliceGatewayStatusOutOfSync(t *testing.T) {
+	baseHub := func() *spokev1alpha1.WorkerSliceGateway {
+		return &spokev1alpha1.WorkerSliceGateway{
+			Spec: spokev1alpha1.WorkerSliceGatewaySpec{
+				SliceName: "demo-slice",
+				LocalGatewayConfig: spokev1alpha1.SliceGatewayConfig{
+					GatewayName:   "gw-local",
+					GatewaySubnet: "10.1.0.0/16",
+					ClusterName:   "local",
+				},
+				RemoteGatewayConfig: spokev1alpha1.SliceGatewayConfig{
+					GatewayName:   "gw-remote",
+					GatewaySubnet: "10.2.0.0/16",
+					ClusterName:   "remote",
+					NodeIps:       []string{"192.0.2.10"},
+					NodePorts:     []int{30001},
+				},
+				GatewayHostType:         "Client",
+				GatewayNumber:           0,
+				GatewayConnectivityType: "NodePort",
+				GatewayProtocol:         "UDP",
+				GatewayType:             hubv1alpha1.SliceGatewayTypeOpenVPN,
+			},
+		}
+	}
+	baseMesh := func() *kubeslicev1beta1.SliceGateway {
+		return &kubeslicev1beta1.SliceGateway{
+			Status: kubeslicev1beta1.SliceGatewayStatus{
+				Config: kubeslicev1beta1.SliceGatewayConfig{
+					SliceName:                    "demo-slice",
+					SliceGatewayID:               "gw-local",
+					SliceGatewaySubnet:           "10.1.0.0/16",
+					SliceGatewayRemoteSubnet:     "10.2.0.0/16",
+					SliceGatewayHostType:         "Client",
+					SliceGatewayRemoteClusterID:  "remote",
+					SliceGatewayRemoteGatewayID:  "gw-remote",
+					SliceGatewayRemoteNodeIPs:    []string{"192.0.2.10"},
+					SliceGatewayNodePorts:        []int{30001},
+					SliceGatewayName:             "0",
+					SliceGatewayConnectivityType: "NodePort",
+					SliceGatewayProtocol:         "UDP",
+					SliceGatewayType:             hubv1alpha1.SliceGatewayTypeOpenVPN,
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(mesh *kubeslicev1beta1.SliceGateway, hub *spokev1alpha1.WorkerSliceGateway)
+		want   bool
+	}{
+		{
+			name: "in sync",
+			mutate: func(_ *kubeslicev1beta1.SliceGateway, _ *spokev1alpha1.WorkerSliceGateway) {
+			},
+			want: false,
+		},
+		{
+			name: "remote cluster id drift",
+			mutate: func(mesh *kubeslicev1beta1.SliceGateway, _ *spokev1alpha1.WorkerSliceGateway) {
+				mesh.Status.Config.SliceGatewayRemoteClusterID = "other"
+			},
+			want: true,
+		},
+		{
+			name: "client node ip drift",
+			mutate: func(_ *kubeslicev1beta1.SliceGateway, hub *spokev1alpha1.WorkerSliceGateway) {
+				hub.Spec.RemoteGatewayConfig.NodeIps = []string{"192.0.2.20"}
+			},
+			want: true,
+		},
+		{
+			name: "client node port drift",
+			mutate: func(_ *kubeslicev1beta1.SliceGateway, hub *spokev1alpha1.WorkerSliceGateway) {
+				hub.Spec.RemoteGatewayConfig.NodePorts = []int{30002}
+			},
+			want: true,
+		},
+		{
+			name: "server ignores remote node fields",
+			mutate: func(mesh *kubeslicev1beta1.SliceGateway, hub *spokev1alpha1.WorkerSliceGateway) {
+				mesh.Status.Config.SliceGatewayHostType = "Server"
+				hub.Spec.GatewayHostType = "Server"
+				mesh.Status.Config.SliceGatewayRemoteNodeIPs = []string{"1.1.1.1"}
+				hub.Spec.RemoteGatewayConfig.NodeIps = []string{"9.9.9.9"}
+				mesh.Status.Config.SliceGatewayNodePorts = []int{111}
+				hub.Spec.RemoteGatewayConfig.NodePorts = []int{222}
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mesh := baseMesh()
+			hub := baseHub()
+			tt.mutate(mesh, hub)
+			if got := MeshSliceGatewayStatusOutOfSync(mesh, hub); got != tt.want {
+				t.Fatalf("MeshSliceGatewayStatusOutOfSync() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This PR adds a small, testable package `pkg/hub/slicegwstatus` with helpers used by the hub `WorkerSliceGateway` reconciler:

- **`WorkerSliceGatewayTargetsCluster`** -> whether the hub `WorkerSliceGateway` is intended for this worker (`LocalGatewayConfig.ClusterName` vs reconciler `ClusterName`).
- **`MeshSliceGatewayStatusOutOfSync`** -> whether the spoke `SliceGateway` `status.config` should be updated from the hub object (static fields plus client remote node IPs / node ports).

`pkg/hub/controllers/slicegateway_controller.go` now calls these helpers. The only behavioral change is logging for the “wrong cluster” path: it uses **`r.ClusterName`** instead of the global `clusterName` env for consistency with the actual early-return condition.

`CONTRIBUTING.md` links for the Code of Conduct and developer guide are updated to **`master`** paths on this repo.

Fixes #470

## How Has This Been Tested?

- `go test ./pkg/hub/slicegwstatus/ -v` (Windows; small package avoids Linux-only vendored deps when testing from `pkg/hub/controllers`)

test-cases
- [x] `TestWorkerSliceGatewayTargetsCluster` -> match vs wrong cluster
- [x] `TestMeshSliceGatewayStatusOutOfSync` :- in sync, remote cluster drift, client node IP/port drift, server ignores remote node fields

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note
NONE