### PR TITLE
fix: remove stdlib log import from slice reconciler SetupWithManager

### DIFF
--- a/controllers/slice/reconciler.go
+++ b/controllers/slice/reconciler.go
@@ -21,7 +21,6 @@ package slice
 import (
 	"context"
 	"fmt"
-	"log"
 	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -405,7 +404,7 @@ func (r *SliceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	sliceSelector := labels.NewSelector()
 	requirement, err := labels.NewRequirement(controllers.ApplicationNamespaceSelectorLabelKey, selection.Exists, nil)
 	if err != nil {
-		log.Fatalf("Error creating label requirement: %v", err)
+		return fmt.Errorf("error creating label requirement: %w", err)
 	}
 	sliceSelector = sliceSelector.Add(*requirement)
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
# Description

`controllers/slice/reconciler.go` was importing the stdlib `"log"` package for a single `log.Fatalf` call inside `SetupWithManager`. This bypasses the structured logger used everywhere else in the project, writes to stderr in a different format, and calls `os.Exit(1)` without giving the controller-runtime manager a chance to run shutdown hooks.

Every other reconciler in this codebase returns errors from `SetupWithManager` — `main.go`already handles them with the structured logger and `os.Exit(1)`. This just makes the slice reconciler consistent with that pattern.

Changed `log.Fatalf("Error creating label requirement: %v", err)` to `return fmt.Errorf("error creating label requirement: %w", err)` and removed the `"log"` import. `fmt` was already imported so no new dependency is added.

Fixes #480 

## How Has This Been Tested?

- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```