### PR TITLE
fix: return (nil, nil) from GetSlice on NotFound to restore graceful requeue

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kubeslice/worker-operator/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,6 +57,9 @@ func GetSlice(ctx context.Context, c client.Client, slice string) (*kubeslicev1b
 		Namespace: ControlPlaneNamespace,
 	}, s)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
# Description

`controllers.GetSlice` was returning `(nil, NotFoundError)` when the Slice CR didn't exist.The SliceGateway reconciler has a `slice == nil` guard at line 127 that requeues after 10 seconds — but it was dead code. `GetSlice` never returned `(nil, nil)`, so a NotFound result always hit the error path and triggered exponential backoff on every gateway reconcile until
the Slice appeared.

Added an `errors.IsNotFound` check in `GetSlice` so it returns `(nil, nil)` on NotFound. Real API errors (permissions, timeouts, network) still propagate as before. The graceful 10s requeue path in the SliceGateway reconciler is now actually reachable.

Fixes #482 

## How Has This Been Tested?

- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```