### PR TITLE
fix: replace shared retryAttempts global with per-Cluster annotation in deregistration handler

### DIFF
--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"time"
 
 	hubv1alpha1 "github.com/kubeslice/apis/pkg/controller/v1alpha1"
@@ -85,7 +86,6 @@ func NewReconciler(c client.Client, mc client.Client, er *events.EventRecorder, 
 	}
 }
 
-var retryAttempts = 0
 var clusterDeregisterFinalizer = "worker.kubeslice.io/cluster-deregister-finalizer"
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -607,15 +607,23 @@ func (r *Reconciler) handleClusterDeletion(cluster *hubv1alpha1.Cluster, ctx con
 		}
 	} else {
 		// The object is being deleted
+		attempts, _ := strconv.Atoi(cluster.Annotations["kubeslice.io/deregistration-attempts"])
 		if controllerutil.ContainsFinalizer(cluster, clusterDeregisterFinalizer) &&
 			cluster.Status.RegistrationStatus != hubv1alpha1.RegistrationStatusDeregisterInProgress &&
-			retryAttempts < MAX_CLUSTER_DEREGISTRATION_ATTEMPTS {
+			attempts < MAX_CLUSTER_DEREGISTRATION_ATTEMPTS {
 			// our finalizer is present, so lets handle any external dependency
 			if err := r.createDeregisterJob(ctx, cluster); err != nil {
 				// unable to deregister the worker operator, return with an error and raise event
 				log.Error(err, "unable to deregister the worker operator")
-				// increment count for retryAttempts
-				retryAttempts++
+				base := cluster.DeepCopy()
+				attempts++
+				if cluster.Annotations == nil {
+					cluster.Annotations = make(map[string]string)
+				}
+				cluster.Annotations["kubeslice.io/deregistration-attempts"] = strconv.Itoa(attempts)
+				if patchErr := r.Patch(ctx, cluster, client.MergeFrom(base)); patchErr != nil {
+					log.Error(patchErr, "unable to patch deregistration attempt count")
+				}
 				statusUpdateErr := r.updateRegistrationStatus(ctx, cluster, hubv1alpha1.RegistrationStatusDeregisterFailed)
 				if statusUpdateErr != nil {
 					log.Error(statusUpdateErr, "unable to update registration status")


### PR DESCRIPTION
# Description

`handleClusterDeletion` was using a package-level `var retryAttempts = 0` to cap deregistration retries at `MAX_CLUSTER_DEREGISTRATION_ATTEMPTS = 3`. This had two problems:

- All Cluster objects shared the same counter. If two clusters were being deleted  simultaneously, failures from one exhausted the retry budget for the other.
- Restarting the operator pod reset the counter to zero, so the "stop after 3 attempts" guarantee didn't actually hold across restarts.

Removed the package-level var and moved attempt tracking into the Cluster object itself using the annotation `kubeslice.io/deregistration-attempts`. On each failed `createDeregisterJob` call, the annotation is incremented and patched back via`client.MergeFrom`. Each Cluster CR now has its own independent counter that survives pod restarts and concurrent deletions of other clusters.

Fixes #484 

## How Has This Been Tested?

- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note
Cluster deregistration attempt count is now tracked via the annotation
`kubeslice.io/deregistration-attempts` on each Cluster CR instead of an in-memory
counter. Existing clusters mid-deletion will lose their in-flight attempt count on
upgrade and restart from zero — they will get up to 3 fresh attempts.
```