### PR TITLE
fix: hub SliceGw controller logs r.ClusterName instead of package-level clusterName

### DIFF
--- a/pkg/hub/controllers/slicegateway_controller.go
+++ b/pkg/hub/controllers/slicegateway_controller.go
@@ -72,7 +72,7 @@ func (r *SliceGwReconciler) Reconcile(ctx context.Context, req reconcile.Request
 	*r.EventRecorder = (*r.EventRecorder).WithSlice(sliceGw.Spec.SliceName)
 	// Return if the slice gw resource does not belong to our cluster
 	if sliceGw.Spec.LocalGatewayConfig.ClusterName != r.ClusterName {
-		log.Info("sliceGw doesn't belong to this cluster", "sliceGw", sliceGw.Name, "cluster", clusterName, "slicegw cluster", sliceGw.Spec.LocalGatewayConfig.ClusterName)
+		log.Info("sliceGw doesn't belong to this cluster", "sliceGw", sliceGw.Name, "cluster", r.ClusterName, "slicegw cluster", sliceGw.Spec.LocalGatewayConfig.ClusterName)
 		return reconcile.Result{}, nil
 	}
 	requeue, result, err := r.handleSliceGWDeletion(sliceGw, ctx, req)


### PR DESCRIPTION
# Description

In `pkg/hub/controllers/slicegateway_controller.go`, the cluster ownership check correctly uses `r.ClusterName` (the value injected into the reconciler at startup):

```go
if sliceGw.Spec.LocalGatewayConfig.ClusterName != r.ClusterName {
```

But the `log.Info` on the next line was using `clusterName` — the package-level variable initialised from `os.Getenv("CLUSTER_NAME")` at package load time. If the env var is empty or unset when the package initialises, the log prints an empty string while the comparison uses the correct injected value. The two variables can diverge, making the log line misleading during debugging.

Fix: replace `clusterName` with `r.ClusterName` in the `log.Info` call so the logged valueis always the same authoritative value used for the ownership check.

Fixes #13

## How Has This Been Tested?

- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [x] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```