### PR TITLE
feat(): add HA Kustomize overlay configuration

### DIFF
--- a/config/ha/kustomization.yaml
+++ b/config/ha/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../default
+
+resources:
+  - pdb.yaml
+
+patchesStrategicMerge:
+  - manager_ha_patch.yaml

--- a/config/ha/kustomization.yaml
+++ b/config/ha/kustomization.yaml
@@ -1,11 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
-  - ../default
+namespace: kubeslice-system
 
 resources:
-  - pdb.yaml
+  - ../default
+  - operator_pdb.yaml
 
-patchesStrategicMerge:
-  - manager_ha_patch.yaml
+patches:
+  - path: manager_ha_patch.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: operator
+

--- a/config/ha/manager_ha_patch.yaml
+++ b/config/ha/manager_ha_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: system
+spec:
+  replicas: 2
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    control-plane: controller-manager

--- a/config/ha/operator_pdb.yaml
+++ b/config/ha/operator_pdb.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: kubeslice-worker-pdb
+  name: kubeslice-operator-pdb
   namespace: system
 spec:
   minAvailable: 1

--- a/config/ha/pdb.yaml
+++ b/config/ha/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kubeslice-worker-pdb
+  namespace: system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below-mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Lays the foundation for running a high-availability `worker-operator` to prevent single-point-of-failure scenarios, aligning with the KubeSlice HA proposal. 
This introduces a dedicated HA Kustomize overlay that allows compiling multi-replica configurations without altering the default single-replica setup.
### Proposed Changes:
- **`config/ha/kustomization.yaml`**: Standard Kustomization base chaining resources and merge patches.
- **`config/ha/manager_ha_patch.yaml`**: Strategic merge patch to scale the `operator` deployment to **2 replicas** and adds preferred pod anti-affinity based on the `kubernetes.io/hostname` topology key to ensure operator pods are scheduled on distinct nodes.
- **`config/ha/pdb.yaml`**: Introduces a `PodDisruptionBudget` for the worker manager requiring `minAvailable: 1` to guarantee high availability during cluster maintenance or node drains.

Fixes # <!-- Mention any issues which might be fixed on this PR merge. -->

## How Has This Been Tested?
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

test-cases
- [ ] Test case A
- [ ] Test case B
-->
Tested locally by building the Kustomize overlay to verify that the strategic merge patches compile successfully and output the correct resources, replicas, and pod anti-affinity constraints.
### Test Cases
- [x] Run `kustomize build config/ha` to verify successful manifest compilation.
- [x] Verify deployment is scaled to 2 replicas with host anti-affinity rules in the compiled manifest.
- [x] Verify the PodDisruptionBudget is correctly rendered and selects the operator deployment.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".
-->

```release-note

```
