### PR TITLE
fix(): updateDashboardCreds uses deprecated ServiceAccount.Secrets field removed in K8s 1.24+

### DIFF
--- a/pkg/hub/controllers/cluster/reconciler.go
+++ b/pkg/hub/controllers/cluster/reconciler.go
@@ -507,27 +507,24 @@ func (r *Reconciler) updateDashboardCreds(ctx context.Context, cr *hubv1alpha1.C
 	log := logger.FromContext(ctx)
 	log.Info("Updating kubernetes dashboard creds")
 
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      KubeSliceDashboardSA,
-			Namespace: controllers.ControlPlaneNamespace,
-		},
-	}
-	if err := r.MeshClient.Get(ctx, types.NamespacedName{Name: sa.Name, Namespace: controllers.ControlPlaneNamespace}, sa); err != nil {
-		log.Error(err, "Error getting service account")
+	secretList := &corev1.SecretList{}
+	if err := r.MeshClient.List(ctx, secretList, client.InNamespace(controllers.ControlPlaneNamespace)); err != nil {
+		log.Error(err, "Error listing secrets for dashboard credentials")
 		return err
 	}
 
-	if len(sa.Secrets) == 0 {
-		err := fmt.Errorf("ServiceAccount has no secret")
-		log.Error(err, "Error getting service account secret")
-		return err
+	var secret *corev1.Secret
+	for i := range secretList.Items {
+		s := &secretList.Items[i]
+		if s.Type == corev1.SecretTypeServiceAccountToken &&
+			s.Annotations[corev1.ServiceAccountNameKey] == KubeSliceDashboardSA {
+			secret = s
+			break
+		}
 	}
-
-	secret := &corev1.Secret{}
-	err := r.MeshClient.Get(ctx, types.NamespacedName{Name: sa.Secrets[0].Name, Namespace: controllers.ControlPlaneNamespace}, secret)
-	if err != nil {
-		log.Error(err, "Error getting service account's secret")
+	if secret == nil {
+		err := fmt.Errorf("no token secret found for ServiceAccount %s", KubeSliceDashboardSA)
+		log.Error(err, "Error getting dashboard token secret")
 		return err
 	}
 
@@ -556,7 +553,7 @@ func (r *Reconciler) updateDashboardCreds(ctx context.Context, cr *hubv1alpha1.C
 		Data: secretData,
 	}
 	log.Info("creating secret on hub", "hubSecret", hubSecret.Name)
-	err = r.Create(ctx, &hubSecret)
+	err := r.Create(ctx, &hubSecret)
 	if apierrors.IsAlreadyExists(err) {
 		err = r.Update(ctx, &hubSecret)
 	}

--- a/pkg/hub/controllers/cluster/reconciler_unit_test.go
+++ b/pkg/hub/controllers/cluster/reconciler_unit_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -397,6 +398,86 @@ func TestUpdateNetworkStatus(t *testing.T) {
 			}
 			test.loadMocks(clientMock, ctx)
 			err := r.updateNetworkStatus(ctx, test.cluster)
+			if test.err != nil && err != nil {
+				if test.err.Error() != err.Error() {
+					t.Error("Expected error:", test.err, " but got ", err)
+				}
+			} else if test.err != err {
+				t.Error("Expected error:", test.err, " but got ", err)
+			}
+		})
+	}
+}
+
+func Test_updateDashboardCreds(t *testing.T) {
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		loadMocks MockClientCall
+		err       error
+	}{
+		{
+			"no token secret found for dashboard SA — returns error",
+			context.WithValue(context.Background(), types.NamespacedName{}, testClusterObj),
+			func(clientMock *utilmock.MockClient, ctx context.Context) {
+				clientMock.On("List",
+					mock.IsType(ctx),
+					mock.IsType(&corev1.SecretList{}),
+					mock.Anything,
+				).Return(nil) // empty list — no matching secret
+			},
+			errors.New("no token secret found for ServiceAccount kubeslice-kubernetes-dashboard"),
+		},
+		{
+			"token secret found via annotation — credentials updated successfully",
+			context.WithValue(context.Background(), types.NamespacedName{}, testClusterObj),
+			func(clientMock *utilmock.MockClient, ctx context.Context) {
+				clientMock.On("List",
+					mock.IsType(ctx),
+					mock.IsType(&corev1.SecretList{}),
+					mock.Anything,
+				).Return(nil).Run(func(args mock.Arguments) {
+					list := args.Get(1).(*corev1.SecretList)
+					list.Items = []corev1.Secret{{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kubeslice-kubernetes-dashboard-token",
+							Namespace: ControlPlaneNamespace,
+							Annotations: map[string]string{
+								corev1.ServiceAccountNameKey: KubeSliceDashboardSA,
+							},
+						},
+						Type: corev1.SecretTypeServiceAccountToken,
+						Data: map[string][]byte{
+							"token":  []byte("test-token"),
+							"ca.crt": []byte("test-ca"),
+						},
+					}}
+				})
+				clientMock.On("Create",
+					mock.IsType(ctx),
+					mock.IsType(&corev1.Secret{}),
+					mock.IsType([]k8sclient.CreateOption(nil)),
+				).Return(nil)
+				clientMock.On("Update",
+					mock.IsType(ctx),
+					mock.IsType(&hubv1alpha1.Cluster{}),
+					mock.IsType([]k8sclient.UpdateOption(nil)),
+				).Return(nil)
+			},
+			nil,
+		},
+	}
+
+	os.Setenv("CLUSTER_NAME", "test-cluster")
+	os.Setenv("HUB_PROJECT_NAMESPACE", "kubeslice-avesha")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := test.ctx
+			clientMock := utilmock.NewClient()
+			mf, _ := metrics.NewMetricsFactory(prometheus.NewRegistry(), metrics.MetricsFactoryOptions{})
+			r := NewReconciler(clientMock, clientMock, nil, mf)
+			test.loadMocks(clientMock, ctx)
+			err := r.updateDashboardCreds(ctx, &hubv1alpha1.Cluster{})
 			if test.err != nil && err != nil {
 				if test.err.Error() != err.Error() {
 					t.Error("Expected error:", test.err, " but got ", err)


### PR DESCRIPTION
# Description

`updateDashboardCreds` in `pkg/hub/controllers/cluster/reconciler.go` was fetching the dashboard token secret via `sa.Secrets[0].Name`. Before Kubernetes 1.24, the API server auto-created a `kubernetes.io/service-account-token` Secret for every ServiceAccount and populated `ServiceAccount.Secrets` with its name. Since 1.24 that auto-creation was removed
`sa.Secrets` is always empty on modern clusters unless a legacy token secret is manually created.

On any K8s 1.24+ cluster this causes `updateDashboardCreds` to return `"ServiceAccount has no secret"` on every single reconcile. Because the error short-circuits`Reconcile()` before `updateClusterHealthStatus` and `updateClusterMetrics` are reached, cluster health status never updates as long as the dashboard SA has no manually-created legacy secret.

Fix: remove the ServiceAccount fetch and replace it with `r.MeshClient.List` over secrets in the control plane namespace, filtering by `Type == kubernetes.io/service-account-token` and `Annotations["kubernetes.io/service-account.name"] == KubeSliceDashboardSA`. This is the correct approach for K8s 1.24+ where token secrets must be created manually and discovered by annotation.

Fixes #489

## How Has This Been Tested?

- [x] `Test_updateDashboardCreds/no_token_secret_found` — empty list returns correct error
- [x] `Test_updateDashboardCreds/token_secret_found_via_annotation` — annotated token secret found, full success path confirmed
- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly
- [x] `make test` — all suites pass; 6 pre-existing spoke timeout failures confirmed identical on master (require live cluster)

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note
action-required: On Kubernetes 1.24+, the dashboard ServiceAccount token secret is no
longer auto-created. Create it manually before upgrading if the KubeSlice dashboard is
enabled:

kubectl create secret generic kubeslice-kubernetes-dashboard-token \
  --type=kubernetes.io/service-account-token \
  --namespace=kubeslice-system \
  --annotations kubernetes.io/service-account.name=kubeslice-kubernetes-dashboard
```