### PR TITLE
 fix: propagate reconcile ctx through NetpolReconciler instead of context.Background()

### DIFF
--- a/pkg/networkpolicy/reconciler.go
+++ b/pkg/networkpolicy/reconciler.go
@@ -73,9 +73,9 @@ func (r *NetpolReconciler) initPrivateIPBlocks() error {
 	return nil
 }
 
-func (c *NetpolReconciler) getSliceNameFromNsOfNetPol(ns string) (string, error) {
+func (c *NetpolReconciler) getSliceNameFromNsOfNetPol(ctx context.Context, ns string) (string, error) {
 	namespace := corev1.Namespace{}
-	err := c.Client.Get(context.Background(), types.NamespacedName{Name: ns}, &namespace)
+	err := c.Client.Get(ctx, types.NamespacedName{Name: ns}, &namespace)
 	if err != nil {
 		c.Log.Error(err, "error while retrieving namespace")
 		return "", err
@@ -102,7 +102,7 @@ func (r *NetpolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	//get the sliceName from namespace label
-	sliceName, err := r.getSliceNameFromNsOfNetPol(req.Namespace)
+	sliceName, err := r.getSliceNameFromNsOfNetPol(ctx, req.Namespace)
 	if err != nil {
 		log.Error(err, "error while retrieving labels from namespace")
 		return ctrl.Result{}, err
@@ -116,7 +116,7 @@ func (r *NetpolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	//get slice
 	slice := &kubeslicev1beta1.Slice{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: sliceName, Namespace: "kubeslice-system"}, slice)
+	err = r.Get(ctx, types.NamespacedName{Name: sliceName, Namespace: "kubeslice-system"}, slice)
 	if err != nil {
 		log.Error(err, fmt.Sprintf("error while retrieving slice(%s/%s)", "kubeslice-system", sliceName))
 		return ctrl.Result{}, err
@@ -145,16 +145,16 @@ func (r *NetpolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	utils.RecordEvent(ctx, r.EventRecorder, slice, nil, ossEvents.EventNetPolAdded, netpolControllerName)
 	log.Info(fmt.Sprintf("added network policy(%s) in slice(%s/%s) of cluster(%s)", netpol.Name, netpol.Namespace, slice.Name, clusterName))
 
-	return r.Compare(&netpol, slice)
+	return r.Compare(ctx, &netpol, slice)
 }
 
-func (c *NetpolReconciler) Compare(np *networkingv1.NetworkPolicy, slice *kubeslicev1beta1.Slice) (ctrl.Result, error) {
-	var ApplicationNamespaces, err1 = c.GetAppNamespacesBySliceNameAndLabel(context.Background(), slice.Name, controllers.ApplicationNamespaceSelectorLabelKey)
+func (c *NetpolReconciler) Compare(ctx context.Context, np *networkingv1.NetworkPolicy, slice *kubeslicev1beta1.Slice) (ctrl.Result, error) {
+	var ApplicationNamespaces, err1 = c.GetAppNamespacesBySliceNameAndLabel(ctx, slice.Name, controllers.ApplicationNamespaceSelectorLabelKey)
 	if err1 != nil {
 		c.Log.Error(err1, "error while retrieving application namespaces by sliceName")
 		return ctrl.Result{}, err1
 	}
-	var AllowedNamespaces, err2 = c.GetAllowedNamespacesBySliceNameAndLabel(context.Background(), slice,
+	var AllowedNamespaces, err2 = c.GetAllowedNamespacesBySliceNameAndLabel(ctx, slice,
 		slicepkg.AllowedNamespaceSelectorLabelKey)
 	if err2 != nil {
 		c.Log.Error(err2, "error while retrieving allowed namespaces by sliceName")
@@ -169,7 +169,7 @@ func (c *NetpolReconciler) Compare(np *networkingv1.NetworkPolicy, slice *kubesl
 				listOpts := []client.ListOption{
 					client.MatchingLabels(networkPolicyPeer.NamespaceSelector.MatchLabels),
 				}
-				err := c.Client.List(context.Background(), namespaceList, listOpts...)
+				err := c.Client.List(ctx, namespaceList, listOpts...)
 				if err != nil {
 					c.Log.Error(err, "error while retrieving namespace")
 					return ctrl.Result{}, err
@@ -180,7 +180,7 @@ func (c *NetpolReconciler) Compare(np *networkingv1.NetworkPolicy, slice *kubesl
 						if !Contains(&ApplicationNamespaces, item.Name) && !Contains(&AllowedNamespaces, item.Name) {
 							clusterName := os.Getenv("CLUSTER_NAME")
 							// Record net pol modified event
-							utils.RecordEvent(context.Background(), c.EventRecorder, slice, nil, ossEvents.EventNetPolScopeWidenedNamespace, netpolControllerName)
+							utils.RecordEvent(ctx, c.EventRecorder, slice, nil, ossEvents.EventNetPolScopeWidenedNamespace, netpolControllerName)
 							c.Log.Info(fmt.Sprintf("widened scope with network policy(%s) in slice(%s/%s) of cluster(%s)",
 								np.Name,
 								slice.Namespace,
@@ -196,7 +196,7 @@ func (c *NetpolReconciler) Compare(np *networkingv1.NetworkPolicy, slice *kubesl
 					if c.isPrivateIP(netpolNet.IP) {
 						clusterName := os.Getenv("CLUSTER_NAME")
 						// Record net pol modified event
-						utils.RecordEvent(context.Background(), c.EventRecorder, slice, nil, ossEvents.EventNetPolScopeWidenedIPBlock, netpolControllerName)
+						utils.RecordEvent(ctx, c.EventRecorder, slice, nil, ossEvents.EventNetPolScopeWidenedIPBlock, netpolControllerName)
 
 						c.Log.Info(fmt.Sprintf("widened scope with network policy(%s) in slice(%s/%s) of cluster("+
 							"%s) : Reason(IPBlock violation)",


### PR DESCRIPTION
# Description

`NetpolReconciler` was using `context.Background()` in five places inside `Compare`, one place inside `getSliceNameFromNsOfNetPol`, and one direct `r.Get` call in `Reconcile`. The reconcile context carries the deadline, cancellation signal, and structured logger set up by controller-runtime — dropping it means API calls in this reconciler ignore timeouts,
can't be cancelled, and lose log correlation with the reconcile run they belong to.

Fixed by threading the reconcile `ctx` through `Compare` (added as a parameter) and `getSliceNameFromNsOfNetPol` (added as a parameter), and replacing every `context.Background()` call with `ctx`.

Fixes #491 

## How Has This Been Tested?

- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly
- [x] `make test` — all suites pass; pre-existing spoke timeout failures confirmed identical on master

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```