### PR TITLE
fix: sync SliceDisplayName on every reconcile in updateSliceConfig

### DIFF
--- a/pkg/hub/controllers/slice_controller.go
+++ b/pkg/hub/controllers/slice_controller.go
@@ -281,6 +281,8 @@ func (r *SliceReconciler) updateSliceConfig(ctx context.Context, meshSlice *kube
 			SliceType:         spokeSlice.Spec.SliceType,
 		}
 	}
+	meshSlice.Status.SliceConfig.SliceDisplayName = spokeSlice.Spec.SliceName
+
 	if meshSlice.Status.SliceConfig.SliceSubnet == "" {
 		meshSlice.Status.SliceConfig.SliceSubnet = spokeSlice.Spec.SliceSubnet
 	}

--- a/pkg/hub/controllers/slice_controller_unit_test.go
+++ b/pkg/hub/controllers/slice_controller_unit_test.go
@@ -384,6 +384,50 @@ func TestUpdateSliceConfigByModyfingSubnetOfControllerSlice(t *testing.T) {
 		t.Error("Expected error:", controllerSlice.Spec.SliceSubnet, " but got ", workerslice.Status.SliceConfig.SliceSubnet)
 	}
 }
+func TestUpdateSliceConfigDisplayNameUpdatedOnSubsequentReconcile(t *testing.T) {
+	client := NewClient()
+	reconciler := &SliceReconciler{
+		Client:     client,
+		MeshClient: client,
+		Log:        ctrl.Log.WithName("controller").WithName("controllers").WithName("SliceConfig"),
+	}
+	ctx := context.WithValue(context.Background(), types.NamespacedName{Name: "test-slice", Namespace: "kubeslice-system"}, controllerSlice)
+
+	client.StatusMock.On("Update",
+		mock.IsType(ctx),
+		mock.IsType(&kubeslicev1beta1.Slice{}),
+		mock.IsType([]k8sclient.SubResourceUpdateOption(nil)),
+	).Return(nil)
+
+	slice := &kubeslicev1beta1.Slice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-slice",
+			Namespace: "kubeslice-system",
+		},
+		Status: kubeslicev1beta1.SliceStatus{
+			SliceConfig: &kubeslicev1beta1.SliceConfig{
+				SliceDisplayName: "old-display-name",
+			},
+		},
+	}
+	hubSlice := &workerv1alpha1.WorkerSliceConfig{
+		Spec: workerv1alpha1.WorkerSliceConfigSpec{
+			SliceName: "new-display-name",
+			SliceGatewayProvider: workerv1alpha1.WorkerSliceGatewayProvider{
+				SliceGatewayServiceType: "NodePort",
+			},
+		},
+	}
+	err := reconciler.updateSliceConfig(ctx, slice, hubSlice)
+	if err != nil {
+		t.Error("Expected no error but got:", err)
+	}
+	if slice.Status.SliceConfig.SliceDisplayName != "new-display-name" {
+		t.Errorf("Expected SliceDisplayName to be updated to %q but got %q",
+			"new-display-name", slice.Status.SliceConfig.SliceDisplayName)
+	}
+}
+
 func TestDeleteSliceResourceOnWorker(t *testing.T) {
 	expected := struct {
 		ctx context.Context


### PR DESCRIPTION
# Description

`updateSliceConfig` in `pkg/hub/controllers/slice_controller.go` only set `SliceDisplayName` inside the `if meshSlice.Status.SliceConfig == nil` block  populated once at first creation and never updated again. If the display name changed in the hub `WorkerSliceConfig`, the worker cluster's `Slice.Status.SliceConfig.SliceDisplayName`  would hold the stale value indefinitely with no way to reconcile it short of deleting and recreating the slice.

All other runtime-mutable fields (QoS profile, namespace isolation, gateway service type, external gateway config, etc.) are already synced unconditionally on every reconcile. `SliceDisplayName` was simply missed. `SliceType` is intentionally left inside the nil guard — it is immutable after slice creation and that behaviour is unchanged.

Fix adds one unconditional assignment after the nil guard, mirroring exactly how `SliceGatewayServiceType` is handled in the same function.

Fixes #493 

## How Has This Been Tested?

Added `TestUpdateSliceConfigDisplayNameUpdatedOnSubsequentReconcile` to `pkg/hub/controllers/slice_controller_unit_test.go`. The test constructs a `Slice` with `SliceConfig` already non-nil (simulating a subsequent reconcile after initial creation) and a stale `SliceDisplayName`, calls `updateSliceConfig` with an updated hub config, and asserts the field is overwritten with the new value.

- [x] `TestUpdateSliceConfigDisplayNameUpdatedOnSubsequentReconcile` — passes
- [x] `make fmt` — no formatting changes
- [x] `make vet` — no issues
- [x] `make build` — builds cleanly
- [x] `make test` — all suites pass; pre-existing spoke timeout failures confirmed identical on master

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have ran `go fmt`
* [ ] I have updated the helm chart as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.
* [ ] I have verified the E2E test cases with new code changes.
* [ ] I have added all the required E2E test cases.

## Does this PR introduce a breaking change?

```release-note

```